### PR TITLE
add page load animation to home page

### DIFF
--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
+import { motion } from 'framer-motion'
 
 import { Contact } from '@/components/contact'
 import { Experience } from '@/components/experience'
@@ -12,12 +13,17 @@ export default function Home() {
   const pathname = usePathname()
   const lang = pathname.split('/')[1] as 'en' | 'es'
   return (
-    <div className="flex flex-col gap-12">
+    <motion.div
+      className="flex flex-col gap-12"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6, ease: 'easeOut' }}
+    >
       <Hero lang={lang} />
       <Experience />
       <Skills />
       <Projects />
       <Contact />
-    </div>
+    </motion.div>
   )
 }


### PR DESCRIPTION
Added a smooth fade-in and slide-up animation using Framer Motion when the main page loads. The animation transitions from opacity 0 to 1 with a subtle 20px upward movement over 0.6 seconds.