### PR TITLE
Update typography to modern font stack (Inter, Bricolage Grotesque, J…

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -4,7 +4,11 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 
 import type { Metadata } from 'next'
 
-import { DM_Sans, Geist, Geist_Mono, Space_Grotesk } from 'next/font/google'
+import {
+  Bricolage_Grotesque,
+  Inter,
+  JetBrains_Mono,
+} from 'next/font/google'
 
 import { BreadcrumbProvider } from '@/components/breadcrumb-provider'
 import { ThemeProvider } from '@/components/theme-provider'
@@ -13,24 +17,20 @@ import { Header } from '@/components/ui/header'
 
 import { getCanonicalUrl } from '@/lib/utils'
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
-})
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-})
-
-const dmSans = DM_Sans({
-  variable: '--font-dm-sans',
+const inter = Inter({
+  variable: '--font-inter',
   subsets: ['latin'],
   display: 'swap',
 })
 
-const spaceGrotesk = Space_Grotesk({
-  variable: '--font-space-grotesk',
+const bricolageGrotesque = Bricolage_Grotesque({
+  variable: '--font-bricolage',
+  subsets: ['latin'],
+  display: 'swap',
+})
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: '--font-jetbrains-mono',
   subsets: ['latin'],
   display: 'swap',
 })
@@ -144,7 +144,7 @@ export default async function RootLayout({
         />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${dmSans.variable} ${spaceGrotesk.variable} flex min-h-screen flex-col`}
+        className={`${inter.variable} ${bricolageGrotesque.variable} ${jetbrainsMono.variable} flex min-h-screen flex-col`}
       >
         <ThemeProvider
           attribute="class"

--- a/app/globals.css
+++ b/app/globals.css
@@ -78,9 +78,9 @@
 }
 
 @theme inline {
-  --font-sans: var(--font-dm-sans), var(--font-geist-sans), sans-serif;
-  --font-mono: var(--font-geist-mono), monospace;
-  --font-heading: var(--font-space-grotesk), var(--font-geist-sans), sans-serif;
+  --font-sans: var(--font-inter), sans-serif;
+  --font-mono: var(--font-jetbrains-mono), monospace;
+  --font-heading: var(--font-bricolage), var(--font-inter), sans-serif;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);


### PR DESCRIPTION
…etBrains Mono)

Replace DM Sans / Space Grotesk / Geist Mono with a more modern and visually appealing font combination:
- Body: Inter — industry-standard modern web font with excellent readability
- Headings: Bricolage Grotesque — distinctive, modern with variable optical sizing
- Code: JetBrains Mono — developer-friendly monospace with ligatures

https://claude.ai/code/session_01DnsavUrKkag1FsxQSmAUS3