### PR TITLE
style(ui): Apply Apple design system and add unit test suite

### DIFF
--- a/.claude/commands/blog-post.md
+++ b/.claude/commands/blog-post.md
@@ -1,0 +1,50 @@
+Create a new bilingual blog post for the lesteban portfolio (content/blog/).
+
+## Steps
+
+1. Ask the user for:
+   - **Title** in English and Spanish
+   - **Short title** (used in cards) in English and Spanish — keep it under 30 chars
+   - **Description** (one sentence) in English and Spanish
+   - **Publish date** — default to today if not specified (format: YYYY-MM-DD)
+   - **Image path** — e.g. `/blog/my-post.jpg` (file must be placed in `public/blog/`)
+   - **Content** — ask if they want a blank scaffold or have a draft to start from
+
+2. Generate the URL slug from the English title:
+   - Lowercase, hyphen-separated, no special chars (e.g. "My First Post" → `my-first-post`)
+   - **The `url` field must be identical in both language files** — this is required for the language switcher
+
+3. Create `content/blog/en/<slug>.md`:
+
+```md
+---
+title: '<English title>'
+short_title: '<English short title>'
+url: '<slug>'
+date: '<YYYY-MM-DD>'
+description: '<English description>'
+image: '<image path>'
+---
+
+<English content or scaffold>
+```
+
+4. Create `content/blog/es/<slug>.md` with the same `url` value:
+
+```md
+---
+title: '<Spanish title>'
+short_title: '<Spanish short title>'
+url: '<slug>'
+date: '<YYYY-MM-DD>'
+description: '<Spanish description>'
+image: '<image path>'
+---
+
+<Spanish content or scaffold>
+```
+
+5. Remind the user:
+   - Place the post image at `public<image path>` before deploying
+   - Run `bun dev` to preview the post at `/en/blog/<slug>` and `/es/blog/<slug>`
+   - Both language versions must exist before merging — the blog listing shows posts for the active locale only

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,39 @@
+Create a git commit for the lesteban portfolio project following conventional commit format.
+
+## Format
+
+```
+<type>(<scope>): <subject>
+```
+
+## Rules
+
+- **type**: `feat`, `fix`, `refac`, `style`, `chore`, `docs`, `test`
+- **scope**: `portfolio`, `blog`, `i18n`, `ui`, `seo`, `config`, `ci`, `deps`
+- **subject**: sentence-case, no period at end, max 72 chars total header
+- Body only if the change needs explanation beyond the title; blank line before body
+- **Never commit directly to `main`** — only commit on feature branches
+
+## Steps
+
+1. Run `git status` to confirm the current branch is NOT `main`. If on `main`, stop and ask the user to switch to a feature branch.
+
+2. Run `git diff --staged` to see what's staged. If nothing is staged, run `git status` and ask the user what to include.
+
+3. Analyze the changes and determine the most appropriate type and scope.
+
+4. Show the commit message to the user and confirm before running `git commit`.
+
+5. Run `git commit -m "<message>"`.
+
+## Examples
+
+```
+feat(blog): Add first marathon post in en and es
+fix(i18n): Correct missing translation key in es dictionary
+refac(ui): Extract BlogCard image into standalone component
+style(portfolio): Align skills grid spacing to 8px base unit
+chore(deps): Bump next to 15.3.1
+docs(config): Update CLAUDE.md with bun commands
+seo(portfolio): Add canonical URLs to blog post pages
+```

--- a/.claude/commands/component.md
+++ b/.claude/commands/component.md
@@ -1,0 +1,46 @@
+Create a new React component for the lesteban portfolio following the project's design system and conventions.
+
+## Steps
+
+1. Ask the user for:
+   - **Component name** (PascalCase)
+   - **Location**: `components/ui/` (primitive), `components/cards/` (composed card), or `components/` root (page section)
+   - **Client or server component** — default to server unless it needs hooks, theme, or browser APIs
+   - **Brief description** of what it does
+
+2. Read one or two existing components in the same target directory to match patterns before writing.
+
+3. Create the component file following these rules:
+
+**Imports order** (enforced by Prettier — must match exactly):
+```ts
+// 1. React (only if needed)
+// 2. Next.js (next/image, next/link, next/navigation)
+// 3. next-themes
+// 4. lucide-react
+// 5. @/components/...
+// 6. @/lib/...
+```
+
+**Design system constraints** (see DESIGN.md for full reference):
+- Use CSS token utilities only — never hardcode hex values
+  - Text: `text-foreground`, `text-primary`, `text-secondary`, `text-muted-foreground`
+  - Background: `bg-background`, `bg-card`, `bg-muted`, `bg-primary`, `bg-secondary`
+  - Border: `border-border`, `border-primary`, `border-secondary`
+  - Destructive: `text-destructive`, `bg-destructive`
+- Headings: add `font-heading` class (Space Grotesk); body uses `font-sans` by default (DM Sans)
+- Dark mode is automatic — tokens switch via `.dark` class; no manual `dark:` overrides needed for color tokens
+- Radius: use `rounded-sm`, `rounded-md`, `rounded-lg`, `rounded-xl`, or `rounded-full` — no arbitrary values
+- Spacing: stick to Tailwind's default scale (multiples of 4px/8px); avoid arbitrary spacing
+- Animations: use existing classes (`animate-fade-in-up`, `animate-fade-in-scale`, `animate-float`) or `tw-animate-css` utilities before writing custom keyframes
+
+**shadcn/ui primitives** available in `components/ui/`:
+- Use them as the base for any new composed component (Card, Badge, Button, etc.)
+- Do not re-implement what shadcn already provides
+
+4. If the component needs i18n strings:
+   - Accept `lang: 'en' | 'es'` as a prop on server components
+   - Use `getClientDictionary(lang)` on client components
+   - Add any new keys to both `app/[lang]/dictionaries/en.json` and `es.json`
+
+5. After creating, verify with `bun typecheck` that there are no type errors.

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,47 @@
+Create a pull request for the current branch with all its changes relative to main.
+
+## Steps
+
+1. Run `git status` to confirm you are NOT on `main`. If on `main`, stop and ask the user to switch to a feature branch.
+
+2. Run the following in parallel:
+   - `git log main...HEAD --oneline` — list all commits on the branch
+   - `git diff main...HEAD --stat` — summarize changed files
+   - `git diff main...HEAD` — full diff for understanding scope
+
+3. Analyze all commits and changes to draft:
+   - **Title** — short (≤70 chars), sentence-case, no period. Use the same type/scope vocabulary as `/commit` (`feat`, `fix`, `style`, `refac`, `test`, `docs`, `chore`).
+   - **Summary** — 2–4 bullets covering what changed and why. Be specific about files and behavior.
+   - **Test plan** — bulleted checklist of what to verify manually or automatically.
+
+4. Check if there are Linear issue IDs referenced in commit messages or branch names (e.g. `LES-37`). If found, mention them in the PR body.
+
+5. Push the branch if it has no upstream yet:
+   ```bash
+   git push -u origin HEAD
+   ```
+
+6. Create the PR with `gh pr create`:
+   ```bash
+   gh pr create --title "<title>" --body "$(cat <<'EOF'
+   ## Summary
+   - ...
+
+   ## Linear issues
+   - Closes LES-XX (if applicable)
+
+   ## Test plan
+   - [ ] ...
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"
+   ```
+
+7. Return the PR URL.
+
+## Rules
+
+- Base branch is always `main`.
+- Never force-push or amend commits as part of this flow.
+- If the diff is empty (branch is identical to main), stop and tell the user there is nothing to open a PR for.

--- a/.claude/commands/linear-issue.md
+++ b/.claude/commands/linear-issue.md
@@ -1,0 +1,30 @@
+Develop and close a Linear issue by its ID.
+
+The issue ID is provided as an argument (e.g. `LES-40`): $ARGUMENTS
+
+## Steps
+
+1. Use `mcp__linear-server__get_issue` with the provided ID to fetch the full issue details (title, description, status).
+
+2. Read the description carefully to understand exactly what needs to be changed and in which files.
+
+3. Read the relevant files before editing them.
+
+4. Implement the changes described in the issue. Follow the project's design system rules in `DESIGN.md` and coding conventions in `CLAUDE.md`.
+
+5. Run `bun typecheck` and `bun lint` to verify no errors were introduced.
+
+6. Use `mcp__linear-server__save_issue` to mark the issue as `Done`:
+   ```
+   id: <issue-id>
+   team: Lesteban
+   state: Done
+   ```
+
+7. Report back: what was changed and confirm the issue is closed.
+
+## Rules
+
+- Never modify files unrelated to the issue scope.
+- If the issue is ambiguous or too broad to implement safely, ask the user to clarify before touching any code.
+- Do not close the issue if `bun typecheck` or `bun lint` fail.

--- a/.claude/commands/retrospective.md
+++ b/.claude/commands/retrospective.md
@@ -1,0 +1,40 @@
+Review the current conversation and update CLAUDE.md and/or any command files in .claude/commands/ to reflect what was learned, decided, or established during this session.
+
+## What to look for
+
+Scan the conversation for:
+
+- **New conventions adopted** — patterns used consistently that aren't documented yet (e.g. a new import order, a new token name, a testing pattern).
+- **New tools or dependencies added** — packages installed, config files created (e.g. `bunfig.toml`, new dev deps).
+- **New commands created or modified** — if a `/command` was added or its behavior was clarified through use.
+- **Decisions about project structure** — where files go, naming rules, what belongs in which directory.
+- **Rules that were applied but aren't written down** — things you had to infer that should be explicit for the next session.
+- **Things that should NOT be added** — corrections made mid-session ("no, don't do X") that should become a documented rule.
+
+Do NOT add:
+- Task-specific details (what issues were fixed today, specific commit messages, PR numbers).
+- Ephemeral state (current branch, current Linear milestone).
+- Anything already documented in CLAUDE.md or the command files.
+
+## Steps
+
+1. Read the full conversation from the beginning.
+
+2. Read the current versions of:
+   - `CLAUDE.md`
+   - All files in `.claude/commands/`
+
+3. For each finding from step 1, decide where it belongs:
+   - **CLAUDE.md** — project-wide conventions, architecture decisions, tooling setup, test infrastructure.
+   - **A specific command file** — a refinement to how that command should behave based on actual usage.
+   - **A new command file** — only if a new repeatable workflow was established.
+
+4. Make the minimal edits needed. Prefer adding a bullet or a short paragraph to an existing section over restructuring the whole file.
+
+5. Report back: list each file touched, what was added/changed, and why.
+
+## Rules
+
+- Keep CLAUDE.md and commands concise — don't pad them with redundant explanation.
+- Write in imperative style ("Use X", "Run Y", "Never Z").
+- If nothing meaningful was learned that isn't already documented, say so and make no changes.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.13
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run tests
+        run: bun test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+bun dev           # Dev server with Turbopack
+bun build         # Production build
+bun lint          # ESLint
+bun lint:fix      # ESLint with auto-fix
+bun format        # Prettier (write)
+bun typecheck     # tsc --noEmit
+
+bun test                    # Run all tests
+bun test lib/blog.test.ts   # Run a single test file
+bun test --watch            # Watch mode
+
+bun create:post             # Interactive CLI to create a new blog post
+```
+
+## Available Skills
+
+| Skill | Trigger | Purpose |
+|-------|---------|---------|
+| `/commit` | When committing changes | Conventional commit with project-specific scopes |
+| `/blog-post` | When creating a new post | Scaffolds bilingual markdown files with correct frontmatter |
+| `/component` | When creating a new component | Generates components following design system constraints |
+
+## Design System
+
+All UI work must follow the design system documented in [`DESIGN.md`](./DESIGN.md). Key rules:
+
+- **Colors:** Use only the CSS tokens defined in `app/globals.css` (`--primary`, `--secondary`, `--accent`, `--destructive`, etc.). Do not hardcode hex values — map to Tailwind utilities (`text-primary`, `bg-secondary`, `border-border`, etc.). Full palette and roles are in `DESIGN.md §2`.
+- **Typography:** `font-sans` (DM Sans) for body, `font-heading` (Space Grotesk) for headings, `font-mono` (Geist Mono) for code. Scale, weights, and tracking rules are in `DESIGN.md §3`.
+- **Spacing & radius:** Follow the radius scale (`rounded-sm` → `rounded-xl`, up to full pills). Base spacing unit is 8px. Details in `DESIGN.md §5`.
+- **Dark mode:** All new components must work in both light and dark mode. Tokens switch automatically via the `.dark` class — avoid hardcoding light-only or dark-only colors.
+- **Depth:** Prefer tonal contrast and border containment over shadows. See elevation levels in `DESIGN.md §6`.
+
+## Architecture
+
+**Next.js 15 App Router portfolio site** with bilingual support. No database — all content is file-based.
+
+### Internationalization
+
+All pages live under `app/[lang]/`. Middleware (`middleware.ts`) detects the `Accept-Language` header and 301-redirects bare paths (e.g. `/about`) to `/en/about` or `/es/about`. Supported locales: `en`, `es`.
+
+Translation strings come from `app/[lang]/dictionaries/{en,es}.json` loaded via `getDictionary(locale)` (server) or `getClientDictionary(locale)` (client). When adding a new UI string, add it to both JSON files.
+
+### Blog System
+
+Posts are Markdown files in `content/blog/en/` and `content/blog/es/`. Frontmatter is parsed with `gray-matter`; Markdown is converted to HTML via `remark` → `rehype` with syntax highlighting. All blog logic lives in `lib/blog.ts` — three main functions: `getAllPosts(lang)`, `getPostByUrl(url, lang)`, `getAllPostUrls(lang)`.
+
+The URL slug of a post must be identical across languages for the language switcher to work correctly.
+
+### Component Organization
+
+- `components/ui/` — shadcn/ui primitives (new-york style, Radix-based)
+- `components/cards/` — composed card components (blog, project, experience, contact)
+- `components/` root — page-section feature components (hero, experience, skills, projects, contact)
+
+### Styling
+
+Tailwind CSS v4 with CSS custom properties defined in `app/globals.css` using the OKLCH color space. The design token names (`--primary`, `--secondary`, `--accent`, etc.) map directly to Tailwind utilities. Dark mode is toggled via the `.dark` class (next-themes).
+
+### Import Order
+
+Prettier enforces this order via `@trivago/prettier-plugin-sort-imports`:
+1. React
+2. Next.js
+3. `next-themes`
+4. `lucide-react`
+5. `@/components/...`
+6. `@/lib/...`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,259 @@
+# Design System Inspired by Apple
+
+## 1. Visual Theme & Atmosphere
+
+Apple's web language is a precision editorial system that alternates between gallery-like calm and retail-density information blocks. The visual tone stays restrained: broad neutral canvases, quiet chrome, and product imagery given almost all of the expressive weight. The interface is engineered to disappear so hardware, materials, and finish options become the narrative foreground.
+
+Across the five analyzed pages, the rhythm is consistent but not monolithic. Marketing surfaces (homepage and Environment) use cinematic black-and-light chaptering, while commerce surfaces (Store and Shop flows) introduce tighter spacing, more utility controls, and denser card stacks without breaking the core brand grammar. The result is one system with two gears: showcase mode and transaction mode.
+
+Typography is the stabilizer. SF Pro Display carries hero and merchandising hierarchy with compact line heights and controlled tracking, while SF Pro Text handles product metadata, navigation, filters, and dense selection UI. The typography stays understated, but the scale range is wide enough to support both billboard hero messaging and micro utility labels.
+
+**Key Characteristics:**
+- Binary section rhythm: light canvases (`#ffffff`, `#f8f8f8`) in light mode alternating with deep dark surfaces (`#181818`, `#292929`) in dark mode
+- Navy-to-teal action family for action and link semantics (`#134686`, `#0089d0`, `#568de9`); coral secondary accent (`#f05461`) for brand highlights
+- Dual operating modes in one system: cinematic showcase modules and dense commerce configurators
+- Heavy reliance on imagery and material finishes; UI chrome remains visually thin
+- Tight headline metrics (SF Pro Display, semibold) paired with compact body/link typography (SF Pro Text)
+- Pill and capsule geometry as signature action language (`18px` to `980px` and circular controls)
+- Depth used sparingly; contrast and surface separation do most of the layering work
+- Multi-page color-block rhythm: black hero chapters -> pale neutral merchandising fields -> utility white retail surfaces -> dark micro-surfaces for controls
+
+## 2. Color Palette & Roles
+
+> **Source:** CSS custom properties defined in `app/globals.css` (Tailwind CSS v4 OKLCH tokens, converted to sRGB hex for reference)
+
+### Primary (Light Mode)
+- **Pure White** (`#ffffff`): Main page background and product list surfaces.
+- **Near-White Canvas** (`#f8f8f8`): Cards, muted areas, and subtle elevated surfaces in light contexts.
+- **Dark Charcoal** (`#3a3a3a`): Primary text and dark-fill control color on light canvases.
+
+### Primary (Dark Mode)
+- **Deep Background** (`#181818`): Main dark mode canvas, immersive section backgrounds, deep UI anchors.
+- **Elevated Card** (`#292929`): Card and raised surface step in dark mode.
+- **Near-Black Popover** (`#030303`): Deepest dark layer for popovers and maximum-contrast elements.
+- **Light Foreground** (`#eeeeee`): Primary text on dark canvases.
+
+### Action & Brand Accent
+- **Navy Primary** (`#134686`): Primary action fill and brand anchor in light mode.
+- **Bright Blue Primary** (`#568de9`): Primary action color in dark mode; high-luminance interactive treatment.
+- **Sky Blue Accent** (`#0089d0`): Inline links and accent treatment for mid-contrast contexts.
+- **Coral Secondary** (`#f05461`): Brand secondary accent for highlights, decorative emphasis, and secondary actions.
+- **Teal Focus Signal** (`#008994`): Ring/focus state and keyboard navigation emphasis across both modes. Dark mode variant: `#0099a3`.
+
+### Surface & Utility
+- **Dark Muted Surface** (`#161616`): Muted and bordered dark surfaces; tight dark utility containment.
+- **Dark Input** (`#0b0b0b`): Form field backgrounds in dark mode.
+
+### Neutrals & Text
+- **Muted Foreground** (`#636363`): Body secondary copy, helper descriptions, tertiary metadata in light mode.
+- **Medium Gray** (`#808080`): Secondary text and muted content in dark mode.
+- **Light Border** (`#dedede`): Dividers, subtle outlines, and field containment in light mode.
+- **Dark Border** (`#161616`): Dividers and outlines in dark mode.
+
+### Semantic & Chart
+- **Selection/Focus Signal** (`#134686` / `#008994`): Shared focus and selected-state signal; navy in action contexts, teal in ring/outline contexts.
+- **Destructive Red** (`#e7000b`): Error states, destructive actions, and warning signals.
+- **Amber** (`#e18528`): Warning-adjacent chart and accent highlight color. Dark mode variant: `#f2943c`.
+- **Teal Chart** (`#008994`): Chart accent 1 and teal data series.
+- **Blue Chart** (`#0089d0`): Chart accent 2 and blue data series.
+
+### Gradient System
+- The interface is predominantly solid-surface driven. Visual richness comes from photography and component layering rather than persistent UI gradients.
+
+## 3. Typography Rules
+
+### Font Family
+- **Display Family:** `SF Pro Display`, fallbacks `SF Pro Icons, Helvetica Neue, Helvetica, Arial, sans-serif`
+- **Text Family:** `SF Pro Text`, fallbacks `SF Pro Icons, Helvetica Neue, Helvetica, Arial, sans-serif`
+- **Usage Split:** Display family handles hero/product headlines and merchandising headings; Text family handles navigation, controls, labels, and dense commerce copy.
+
+### Hierarchy
+| Role | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|--------|-------------|----------------|-------|
+| Hero Display XL | 80px | 600 | 1.00-1.05 | -1.2px | Environment/store hero scale |
+| Hero Display L | 56px | 600 | 1.07 | -0.28px | Homepage hero moments |
+| Section Display | 48px | 500-600 | 1.08 | -0.144px | Major chapter headings |
+| Product Heading | 40px | 600 | 1.10 | normal | Product and campaign section titles |
+| Feature Display | 38px | 600 | 1.21 | 0.152px | Device and merchandising callouts |
+| Promo Display | 32px | 300-600 | 1.09-1.13 | 0.128px to 0.352px | Module-level sub-heroes |
+| Card/Product Title | 28px | 600 | 1.14 | 0.196px | Tile-level naming and key copy |
+| Utility Heading | 24px | 600 | 1.17 | 0.216px / -0.2px | Configurator and grouped content headers |
+| Link/Action Heading | 21px | 600 | 1.14-1.38 | 0.231px | Larger promotional links |
+| Subhead | 19px | 600 | 1.21 | 0.228px | Compact section intros |
+| Body Primary | 17px | 400 | 1.47 | -0.374px | Standard body and retail descriptions |
+| Body Emphasis | 17px | 600 | 1.24 | -0.374px | Emphasized labels and key values |
+| Control Label | 14px | 400-600 | 1.29-1.47 | -0.224px | Buttons, helper labels, compact nav text |
+| Micro UI | 12px | 400-600 | 1.00-1.33 | -0.12px | Fine print, micro labels |
+| Legal/Meta | 10px | 400 | 1.30-1.47 | -0.08px | Dense metadata and legal support text |
+
+### Principles
+- **Continuity across page types:** The same typographic DNA spans cinematic launches and product-purchase flows, preventing a brand split between marketing and commerce.
+- **Compression at scale:** Display tiers use tight leading and controlled tracking to feel machined and product-first.
+- **Readable density at retail depth:** SF Pro Text balances compactness with enough vertical rhythm for long product lists and option matrices.
+- **Measured weight ladder:** 600 is the dominant emphasis weight; 700 appears selectively; 300 is used sparingly for contrast in larger lines.
+
+### Note on Font Substitutes
+- Closest freely available substitutes: `Inter` for text-heavy implementation and `SF Pro Display-like` metrics approximated with `Inter Tight` for headings.
+- When substituting, increase line-height slightly (+0.02 to +0.06) on body sizes and reduce negative tracking intensity to preserve readability.
+
+## 4. Component Stylings
+
+### Buttons
+- **Primary Fill Action:** `#134686` background, `#ffffff` text, 8px radius, compact horizontal padding (commonly 8px 15px). Dark mode: `#568de9` background. Used for decisive purchase/progression actions.
+- **Dark Fill Action:** `#3a3a3a` background, `#ffffff` text, 8px radius. Used when light surfaces need a restrained high-contrast primary.
+- **Pill/Capsule Action Family:** large capsule actions at `18px`-`56px` radii and extreme pill links at `980px`. Establishes the soft but precise call-to-action silhouette.
+- **Utility Filter/Button Shells:** light shells (`#f8f8f8` or translucent white) with subtle gray borders (`#dedede`) for dense configuration contexts.
+- **Pressed Behavior:** active controls commonly reduce scale or shift fill slightly to indicate physical press confirmation.
+
+### Cards & Containers
+- **Editorial/Product Cards:** light cards on `#f8f8f8` or white fields with minimal framing and image-first composition.
+- **Dark Utility Cards:** dark steps (`#292929` to `#161616`) used for overlays, media controls, and dark-context modules.
+- **Configurator Panels:** rounded containers (often 12px-18px) with clear but restrained border definition.
+- **Carousel/Spotlight Modules:** larger rounded shells (`28px`-`36px`) for featured content lanes.
+
+### Inputs & Forms
+- **Retail Input Fields:** translucent or white backgrounds (`#f8f8f8`), dark text (`#3a3a3a`), border-led containment (`#dedede`).
+- **Selection Controls:** circular/toggle-like control geometry appears frequently in product selection interfaces.
+- **Density Strategy:** form fields remain visually quiet to keep device imagery and pricing hierarchy dominant.
+
+### Navigation
+- **Global Marketing Nav:** compact dark translucent bar with small-type links and restrained iconography.
+- **Store/Sub-shop Nav Layers:** additional utility bars, chips, and segmented controls for category and product narrowing.
+- **Link Hierarchy:** link blues remain the primary interactive signal while neutral text supports dense navigation sets.
+
+### Image Treatment
+- **Object-First Photography:** hardware and accessories are foregrounded on controlled solid surfaces.
+- **High-fidelity finish rendering:** reflective/material details are central to visual persuasion.
+- **Mixed framing:** full-bleed hero scenes coexist with rounded retail cards and tightly cropped merchandising thumbnails.
+
+### Other Distinctive Components
+- **Product Configurator Matrix:** option stacks and selectors combining chips, radio-style controls, and contextual pricing/summary blocks.
+- **Carousel Control Dots/Arrows:** circular control vocabulary in muted overlays for gallery progression.
+- **Environment Story Panels:** narrative chapters that blend editorial typography with cinematic product/environment visuals.
+
+## 5. Layout Principles
+
+### Spacing System
+- Base unit is effectively `8px`, but the system supports dense micro-steps for precision alignment.
+- Frequently reused spacing values across pages: `2`, `4`, `6`, `7`, `8`, `9`, `10`, `12`, `14`, `17`, `20` px.
+- Universal rhythm constants visible across both marketing and retail flows: `8px` unit scaffolding with `14-20px` utility intervals for component padding and list spacing.
+
+### Grid & Container
+- **Showcase pages:** large central columns with broad horizontal breathing room and full-width color chapters.
+- **Commerce pages:** tighter multi-column product and control grids with frequent modular stacking.
+- **Container behavior:** constrained readable core with generous outer margins at desktop widths.
+
+### Whitespace Philosophy
+- **Scene pacing:** major visual chapters use broad top/bottom breathing room.
+- **Information compaction where needed:** retail pages deliberately compress spacing to expose more actionable information per viewport.
+- **Contrast-led separation:** section transitions rely more on surface changes than decorative separators.
+
+### Border Radius Scale
+- **5px:** tiny utility links/tags and minor small shells.
+- **8px-12px:** standard controls and compact fields.
+- **16px-18px:** cards, module frames, and commerce panels.
+- **28px-36px:** larger module and spotlight containers.
+- **56px / 100px / 980px:** capsules, large pills, and signature elongated CTA forms.
+- **50%:** circular media and selection controls.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|------|-----------|-----|
+| Level 0 | Flat neutral surfaces (`#ffffff`, `#f8f8f8` / dark: `#181818`) | Main narrative and product stages |
+| Level 1 | Subtle border containment (`#dedede` / dark: `#161616`) | Filters, input fields, utility cards |
+| Level 2 | Soft shadow (`rgba(0,0,0,0.08)` to `rgba(0,0,0,0.22)` where present) | Highlighted cards and elevated merchandise modules |
+| Level 3 | Dark-surface stepping (`#292929` → `#161616` → `#030303`) | Overlays, media controls, dark utility clusters |
+| Accessibility | Navy/teal focus signal (`#134686` / `#008994`) | Keyboard and selection emphasis |
+
+Depth is intentionally restrained. Apple favors tonal contrast, surface stepping, and compositional hierarchy over heavy shadow stacks.
+
+### Decorative Depth
+- Decorative depth is primarily created by photographic realism and material rendering, not synthetic UI effects.
+- Translucent overlays and glass-like utility bars provide mild atmospheric layering in navigation and controls.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use the neutral foundation (`#ffffff`, `#f8f8f8` / dark: `#181818`, `#292929`) as the structural foundation.
+- Reserve blue accents for genuine action and navigation semantics.
+- Keep typography tight and deliberate, especially at display scales.
+- Maintain the capsule/circle geometry language for controls and key actions.
+- Let product imagery carry visual drama; keep chrome understated.
+- Use border-led containment in dense retail contexts instead of heavy card ornamentation.
+- Preserve clear separation between showcase modules and transactional modules while keeping core tokens shared.
+
+### Don't
+- Don’t introduce additional accent palettes beyond navy primary (`#134686`), sky blue accent (`#0089d0`), and coral secondary (`#f05461`).
+- Don’t overuse shadows, glow effects, or decorative gradients in core UI chrome.
+- Don’t mix unrelated font families or loosen tracking indiscriminately.
+- Don’t flatten all corners to a single radius; Apple uses purposeful radius tiers.
+- Don’t overload commerce modules with thick borders or loud visual effects.
+- Don’t remove neutral contrast cadence between dark and light chapters.
+- Don’t treat marketing and purchase flows as separate design systems.
+
+## 8. Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Small Mobile | 374px and below | Tightened retail controls, single-column product stacks |
+| Mobile | 375px-640px | One-column modules, compact action rows, condensed selectors |
+| Tablet | 641px-833px | Expanded cards and mixed 1-2 column transitions |
+| Tablet Wide | 834px-1023px | More stable multi-column merchandising, larger text blocks |
+| Desktop | 1024px-1240px | Full retail layouts and product comparison structures |
+| Desktop Wide | 1241px-1440px | Marketing hero expansion and broader section spacing |
+| Large Desktop | 1441px+ | Maximum chapter breathing room and wide editorial composition |
+
+### Touch Targets
+- Primary and secondary actions are generally presented in tap-friendly pill/button geometries.
+- Circular media and selection controls align with minimum touchable intent in mobile contexts.
+- Dense commerce UI uses compact labels but maintains clear hit regions via surrounding shape padding.
+
+### Collapsing Strategy
+- Marketing hero typography scales down in discrete tiers while preserving hierarchy contrast.
+- Product and commerce grids collapse from multi-column to stacked cards with persistent selector visibility.
+- Utility navigation compresses into simpler link/control groupings while preserving key actions.
+- Option/configuration clusters become vertically sequenced to keep purchase flow linear on small screens.
+
+### Image Behavior
+- Product imagery preserves aspect and centrality through breakpoints.
+- Hero visuals remain dominant on mobile, with text repositioned around media priority.
+- Retail thumbnails stay legible via tighter crop logic and denser card stacking.
+- Image-led modules continue to anchor the rhythm as layout density increases.
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Primary action (light mode): **Navy Primary** (`#134686`)
+- Primary action (dark mode): **Bright Blue** (`#568de9`)
+- Inline link / accent: **Sky Blue** (`#0089d0`)
+- Secondary brand accent: **Coral** (`#f05461`)
+- Focus / ring signal: **Teal** (`#008994`)
+- Dark mode canvas: **Deep Background** (`#181818`)
+- Light mode canvas: **Near-White Canvas** (`#f8f8f8`)
+- Primary text (light): **Dark Charcoal** (`#3a3a3a`)
+- Primary text (dark): **Light Foreground** (`#eeeeee`)
+- Secondary text: **Muted Foreground** (`#636363`)
+- Border (light): **Light Border** (`#dedede`)
+- Destructive / error: **Destructive Red** (`#e7000b`)
+
+### Example Component Prompts
+- "Design a product hero on a dark canvas (`#181818`) with Space Grotesk semibold headline (48-56px), concise supporting copy, and two capsule CTAs using `#568de9` and `#f05461`."
+- "Create a configuration panel on white (`#ffffff`) with 18px rounded cards, `#dedede` border fields, DM Sans 17px body copy, and compact option selectors."
+- "Build a card grid alternating `#f8f8f8` and white surfaces, with image-first cards, restrained shadows, and 14-17px DM Sans metadata."
+- "Generate a carousel control cluster using circular buttons (50% radius), muted gray overlays, and clear active feedback for gallery navigation."
+- "Compose a mixed marketing + editorial page rhythm: dark showcase chapter (`#181818`) -> light feature chapter (`#f8f8f8`) -> dense card module while keeping navy/teal accents only for actions and links."
+
+### Iteration Guide
+1. Lock the neutral foundation first (`#ffffff`, `#f8f8f8` / dark: `#181818`, `#292929`) before tuning accents.
+2. Keep blue accents scarce and purposeful; if everything is blue, hierarchy collapses.
+3. Tune typography in this order: display scale, body readability, then micro labels.
+4. Match radius by component class (field, card, capsule, circle) rather than one-size-fits-all rounding.
+5. Increase density gradually when moving from showcase sections to commerce sections.
+6. Validate that product imagery remains the strongest visual layer after each revision.
+
+### Known Gaps
+- Destructive/error is defined (`#e7000b`); success and warning tokens are not explicitly defined — use amber (`#e18528`) for warning-adjacent states and derive success from a compatible green if needed.
+- Some interaction micro-states vary by module and are not represented as universal system tokens.
+- A few modules expose context-specific typography overrides that do not appear as shared system tokens.

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "3",
+        "@happy-dom/global-registrator": "^20.9.0",
         "@tailwindcss/postcss": "4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -39,6 +40,7 @@
         "@types/react-dom": "19",
         "eslint": "9",
         "eslint-config-next": "15.3.2",
+        "happy-dom": "^20.9.0",
         "prettier": "^3.6.2",
         "tailwindcss": "4",
         "tw-animate-css": "1.2.9",
@@ -102,6 +104,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.2", "", { "dependencies": { "@floating-ui/dom": "^1.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.9", "", {}, "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -325,6 +329,10 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.32.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.32.1", "@typescript-eslint/type-utils": "8.32.1", "@typescript-eslint/utils": "8.32.1", "@typescript-eslint/visitor-keys": "8.32.1", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.32.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.32.1", "@typescript-eslint/types": "8.32.1", "@typescript-eslint/typescript-estree": "8.32.1", "@typescript-eslint/visitor-keys": "8.32.1", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg=="],
@@ -539,6 +547,8 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "es-abstract": ["es-abstract@1.23.9", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.3", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.0", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-regex": "^1.2.1", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.0", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.3", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.3", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.18" } }, "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
@@ -668,6 +678,8 @@
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1225,6 +1237,8 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
@@ -1238,6 +1252,8 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./tests/setup.ts"]

--- a/components/cards/blog-card.tsx
+++ b/components/cards/blog-card.tsx
@@ -21,7 +21,7 @@ export function BlogCard({ post }: { post: BlogPost }) {
 
   return (
     <NextLink href={`/${lang}/blog/${post.url}`}>
-      <Card className="border-secondary group flex h-full w-full cursor-pointer flex-col gap-0 overflow-hidden border-2 p-0 transition-all duration-300 hover:shadow-lg">
+      <Card className="border-secondary group flex h-full w-full cursor-pointer flex-col gap-0 overflow-hidden border-2 p-0 transition-all duration-300 hover:border-primary/50">
         <div className="relative block h-64 w-full overflow-hidden lg:h-56">
           <Image
             src={post.image}
@@ -33,7 +33,7 @@ export function BlogCard({ post }: { post: BlogPost }) {
         </div>
         <CardHeader className="w-full flex-1 px-0">
           <CardTitle className="group-hover:text-primary flex w-full items-start justify-between gap-2 px-6 py-4 transition-colors">
-            <span className="text-lg font-bold">{post.title}</span>
+            <span className="font-heading text-lg font-bold">{post.title}</span>
           </CardTitle>
         </CardHeader>
       </Card>

--- a/components/cards/experience-card.tsx
+++ b/components/cards/experience-card.tsx
@@ -22,14 +22,14 @@ export function ExperienceCard({ job }: { job: ExperienceType }) {
   const lang = pathname.split('/')[1] as 'en' | 'es'
   const dictionary = getClientDictionary(lang)
   return (
-    <div className="mb-4 flex flex-col gap-2">
-      <h3 className="text-primary text-lg font-bold">
+    <div className="bg-card border-border flex flex-col gap-2 rounded-lg border p-4">
+      <h3 className="font-heading text-primary text-lg font-bold">
         {dictionary[job.position as keyof typeof dictionary]}
       </h3>
       <div className="flex items-center gap-2">
-        <h2 className="font-bold">{job.company}</h2>
+        <h2 className="font-heading font-bold">{job.company}</h2>
         <Calendar className="ml-1 h-4 w-4 font-bold" />
-        <h2 className="font-bold">
+        <h2 className="font-heading font-bold">
           {dictionary[job.startDate as keyof typeof dictionary]} -{' '}
           {dictionary[job.endDate as keyof typeof dictionary]}
         </h2>

--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -55,7 +55,7 @@ export function Contact() {
   if (!mounted) {
     return (
       <div className="flex flex-col gap-4">
-        <h1 className="text-primary text-2xl font-bold">
+        <h1 className="font-heading text-primary text-2xl font-bold">
           {dictionary['contact']}
         </h1>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -71,7 +71,7 @@ export function Contact() {
 
   return (
     <div className="flex flex-col gap-4">
-      <h1 className="text-primary text-2xl font-bold">
+      <h1 className="font-heading text-primary text-2xl font-bold">
         {dictionary['contact']}
       </h1>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">

--- a/components/experience.tsx
+++ b/components/experience.tsx
@@ -49,7 +49,7 @@ export function Experience() {
 
   return (
     <div className="items-betwee flex flex-col gap-5">
-      <h1 className="text-primary text-2xl font-bold">
+      <h1 className="font-heading text-primary text-2xl font-bold">
         {dictionary['experience']}
       </h1>
       <ExperienceCard job={EXPERIENCE.aleluya} />

--- a/components/projects.tsx
+++ b/components/projects.tsx
@@ -43,7 +43,7 @@ export function Projects() {
   const dictionary = getClientDictionary(lang)
   return (
     <div className="flex flex-col gap-4">
-      <h1 className="text-primary text-2xl font-bold">
+      <h1 className="font-heading text-primary text-2xl font-bold">
         {dictionary['projects']}
       </h1>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">

--- a/components/skills.tsx
+++ b/components/skills.tsx
@@ -28,7 +28,7 @@ function Skill({
     <div className="flex flex-col gap-2">
       <div className="flex gap-2">
         {icon}
-        <h3 className="text-lg font-bold">{skill}</h3>
+        <h3 className="font-heading text-lg font-bold">{skill}</h3>
       </div>
       <div className="flex flex-wrap gap-2">
         {skills.map((skill) => {
@@ -53,33 +53,33 @@ export function Skills() {
   const dictionary = getClientDictionary(lang)
   return (
     <div className="flex flex-col gap-4">
-      <h1 className="text-primary text-2xl font-bold">{dictionary.skills}</h1>
+      <h1 className="font-heading text-primary text-2xl font-bold">{dictionary.skills}</h1>
       <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
         <Skill
           skill={dictionary['frontend-development' as keyof typeof dictionary]}
           icon={
-            <Layout className="h-5 w-5 animate-bounce text-blue-500 [animation-duration:1s]" />
+            <Layout className="h-5 w-5 transition-transform duration-300 hover:scale-110text-primary" />
           }
           skills={SKILLS.frontend}
         />
         <Skill
           skill={dictionary['backend-development' as keyof typeof dictionary]}
           icon={
-            <Server className="h-5 w-5 animate-bounce text-green-500 [animation-duration:1s]" />
+            <Server className="h-5 w-5 transition-transform duration-300 hover:scale-110text-accent" />
           }
           skills={SKILLS.backend}
         />
         <Skill
           skill={dictionary['database' as keyof typeof dictionary]}
           icon={
-            <Database className="h-5 w-5 animate-bounce text-orange-500 [animation-duration:1s]" />
+            <Database className="h-5 w-5 transition-transform duration-300 hover:scale-110text-chart-5" />
           }
           skills={SKILLS.database}
         />
         <Skill
           skill={dictionary['programing-languages' as keyof typeof dictionary]}
           icon={
-            <Code className="h-5 w-5 animate-bounce text-red-500 [animation-duration:1s]" />
+            <Code className="h-5 w-5 transition-transform duration-300 hover:scale-110text-secondary" />
           }
           skills={SKILLS.programing_languages}
         />

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-title"
-      className={cn('leading-none font-semibold', className)}
+      className={cn('font-heading leading-none font-semibold', className)}
       {...props}
     />
   )

--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -27,7 +27,7 @@ export function Footer() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.5, delay: 0.2 }}
-            className="text-slate-500"
+            className="text-muted-foreground"
           >
             {dictionary['made-with' as keyof typeof dictionary]}
           </motion.span>
@@ -41,13 +41,13 @@ export function Footer() {
               repeatType: 'reverse',
             }}
           >
-            <Heart className="h-4 w-4 fill-red-500 text-red-500" />
+            <Heart className="h-4 w-4 fill-secondary text-secondary" />
           </motion.div>
           <motion.span
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.5, delay: 0.3 }}
-            className="text-slate-500"
+            className="text-muted-foreground"
           >
             {dictionary['by' as keyof typeof dictionary]}
           </motion.span>

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -77,7 +77,7 @@ export function Header() {
   }
 
   return (
-    <header className="bg-background fixed top-0 right-0 left-0 z-10 flex h-16 w-full items-center border-b-1 border-gray-100 py-1 dark:border-gray-700">
+    <header className="bg-background fixed top-0 right-0 left-0 z-10 flex h-16 w-full items-center border-b border-border py-1">
       <div className="flex w-full items-center justify-between">
         <div className="md:flex-1" />
         <div className="flex w-full items-center justify-between px-2 md:px-4 lg:w-3/6 lg:px-0 2xl:w-2/6">

--- a/lib/blog.test.ts
+++ b/lib/blog.test.ts
@@ -98,5 +98,58 @@ describe('Blog Utilities', () => {
       const urls = await getAllPostUrls('en')
       expect(urls.length).toBe(posts.length)
     })
+
+    test('should not contain URLs with leading or trailing slashes', async () => {
+      const urls = await getAllPostUrls('en')
+      for (const url of urls) {
+        expect(url.startsWith('/')).toBe(false)
+        expect(url.endsWith('/')).toBe(false)
+      }
+    })
+
+    test('should not contain duplicate URLs', async () => {
+      const urls = await getAllPostUrls('en')
+      const unique = new Set(urls)
+      expect(unique.size).toBe(urls.length)
+    })
+  })
+
+  describe('language parity', () => {
+    test('en and es have the same number of posts', async () => {
+      const enPosts = await getAllPosts('en')
+      const esPosts = await getAllPosts('es')
+      expect(enPosts.length).toBe(esPosts.length)
+    })
+
+    test('all post URLs match across en and es', async () => {
+      const enUrls = (await getAllPostUrls('en')).sort()
+      const esUrls = (await getAllPostUrls('es')).sort()
+      expect(enUrls).toEqual(esUrls)
+    })
+  })
+
+  describe('data integrity', () => {
+    test('all posts have a valid date string', async () => {
+      const posts = await getAllPosts('en')
+      for (const post of posts) {
+        expect(isNaN(Date.parse(post.date))).toBe(false)
+      }
+    })
+
+    test('getPostByUrl returns non-empty content', async () => {
+      const posts = await getAllPosts('en')
+      if (posts.length > 0) {
+        const post = await getPostByUrl(posts[0].url, 'en')
+        expect((post?.content ?? '').length).toBeGreaterThan(0)
+      }
+    })
+
+    test('getPostByUrl returns readingTime greater than 0', async () => {
+      const posts = await getAllPosts('en')
+      if (posts.length > 0) {
+        const post = await getPostByUrl(posts[0].url, 'en')
+        expect(post?.readingTime).toBeGreaterThan(0)
+      }
+    })
   })
 })

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test'
+
+import { cn, getCanonicalUrl } from './utils'
+
+describe('cn', () => {
+  test('combines classes correctly', () => {
+    expect(cn('px-2', 'py-4')).toBe('px-2 py-4')
+  })
+
+  test('resolves Tailwind conflicts keeping last value', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+
+  test('handles undefined values', () => {
+    expect(cn('px-2', undefined, 'py-4')).toBe('px-2 py-4')
+  })
+
+  test('handles false values', () => {
+    expect(cn('px-2', false, 'py-4')).toBe('px-2 py-4')
+  })
+
+  test('handles null values', () => {
+    expect(cn('px-2', null, 'py-4')).toBe('px-2 py-4')
+  })
+
+  test('returns empty string with no arguments', () => {
+    expect(cn()).toBe('')
+  })
+
+  test('deduplicates conflicting padding classes', () => {
+    expect(cn('px-2', 'px-6')).toBe('px-6')
+  })
+})
+
+describe('getCanonicalUrl', () => {
+  test('returns full URL for path with leading slash', () => {
+    expect(getCanonicalUrl('/about')).toBe('https://lesteban.dev/about')
+  })
+
+  test('adds leading slash when path has none', () => {
+    expect(getCanonicalUrl('about')).toBe('https://lesteban.dev/about')
+  })
+
+  test('does not duplicate the leading slash', () => {
+    const url = getCanonicalUrl('/about')
+    expect(url).not.toContain('lesteban.dev//')
+  })
+
+  test('works with nested paths', () => {
+    expect(getCanonicalUrl('/blog/my-post')).toBe(
+      'https://lesteban.dev/blog/my-post'
+    )
+  })
+
+  test('works with locale prefix', () => {
+    expect(getCanonicalUrl('/en/blog/my-post')).toBe(
+      'https://lesteban.dev/en/blog/my-post'
+    )
+  })
+
+  test('works with root path', () => {
+    expect(getCanonicalUrl('/')).toBe('https://lesteban.dev/')
+  })
+})

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test'
+import { NextRequest } from 'next/server'
+
+import { getLocale, middleware } from './middleware'
+
+describe('getLocale', () => {
+  const headers = (value: string | null) => ({
+    get: (key: string) => (key === 'accept-language' ? value : null),
+  })
+
+  test('returns "es" for Accept-Language: es', () => {
+    expect(getLocale(headers('es'))).toBe('es')
+  })
+
+  test('returns "en" for Accept-Language: en-US', () => {
+    expect(getLocale(headers('en-US'))).toBe('en')
+  })
+
+  test('returns "es" for Accept-Language: es-CO', () => {
+    expect(getLocale(headers('es-CO'))).toBe('es')
+  })
+
+  test('returns "en" fallback for unsupported locale', () => {
+    expect(getLocale(headers('fr'))).toBe('en')
+  })
+
+  test('returns "en" fallback when header is absent', () => {
+    expect(getLocale(headers(null))).toBe('en')
+  })
+})
+
+describe('middleware', () => {
+  function makeRequest(pathname: string, acceptLanguage?: string) {
+    return new NextRequest(new URL(`http://localhost${pathname}`), {
+      headers: acceptLanguage ? { 'accept-language': acceptLanguage } : {},
+    })
+  }
+
+  test('redirects /about to /en/about with status 301', () => {
+    const res = middleware(makeRequest('/about'))
+    expect(res).toBeDefined()
+    expect(res?.status).toBe(301)
+    expect(res?.headers.get('location')).toContain('/en/about')
+  })
+
+  test('redirects / to /en with status 301', () => {
+    const res = middleware(makeRequest('/'))
+    expect(res).toBeDefined()
+    expect(res?.status).toBe(301)
+  })
+
+  test('does not redirect /en/about', () => {
+    const res = middleware(makeRequest('/en/about'))
+    expect(res).toBeUndefined()
+  })
+
+  test('does not redirect /es/blog', () => {
+    const res = middleware(makeRequest('/es/blog'))
+    expect(res).toBeUndefined()
+  })
+
+  test('does not redirect /en (exact locale path)', () => {
+    const res = middleware(makeRequest('/en'))
+    expect(res).toBeUndefined()
+  })
+
+  test('redirects to /es/about when Accept-Language is es', () => {
+    const res = middleware(makeRequest('/about', 'es'))
+    expect(res?.headers.get('location')).toContain('/es/about')
+  })
+})

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,13 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 
 const locales = ['en', 'es']
 
-// Get the preferred locale, similar to the above or using a library
-function getLocale(request: NextRequest) {
-  const acceptLanguage = request.headers.get('accept-language')?.split(',')[0]
-  // Extract the language part (e.g., "en" from "en-US")
+export function getLocale(headers: { get: (key: string) => string | null }): string {
+  const acceptLanguage = headers.get('accept-language')?.split(',')[0]
   const language = acceptLanguage?.split('-')[0]
-  // Return the language if it's supported, otherwise default to "en"
-  return locales.includes(language || '') ? language : 'en'
+  return locales.includes(language || '') ? (language as string) : 'en'
 }
 
 export function middleware(request: NextRequest) {
@@ -21,7 +18,7 @@ export function middleware(request: NextRequest) {
   if (pathnameHasLocale) return
 
   // Redirect if there is no locale
-  const locale = getLocale(request)
+  const locale = getLocale(request.headers)
   request.nextUrl.pathname = `/${locale}${pathname}`
   // e.g. incoming request is /products
   // The new URL is now /en/products

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "3",
+    "@happy-dom/global-registrator": "^20.9.0",
     "@tailwindcss/postcss": "4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
@@ -51,6 +52,7 @@
     "@types/react-dom": "19",
     "eslint": "9",
     "eslint-config-next": "15.3.2",
+    "happy-dom": "^20.9.0",
     "prettier": "^3.6.2",
     "tailwindcss": "4",
     "tw-animate-css": "1.2.9",

--- a/tests/cards.test.tsx
+++ b/tests/cards.test.tsx
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import React from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+
+mock.module('next/navigation', () => ({
+  usePathname: () => '/en',
+}))
+
+mock.module('next/link', () => ({
+  default: ({
+    href,
+    children,
+    target,
+  }: {
+    href: string
+    children: React.ReactNode
+    target?: string
+  }) => React.createElement('a', { href, target }, children),
+}))
+
+mock.module('next/image', () => ({
+  default: ({
+    src,
+    alt,
+    fill: _fill,
+    sizes: _sizes,
+    ...rest
+  }: {
+    src: string
+    alt: string
+    fill?: boolean
+    sizes?: string
+    [key: string]: unknown
+  }) => React.createElement('img', { src, alt, ...rest }),
+}))
+
+mock.module('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' }),
+}))
+
+mock.module('@/hooks/use-has-mounted', () => ({
+  useHasMounted: () => true,
+}))
+
+const MOCK_DICT: Record<string, string> = {
+  roadmapcol: 'Roadmapcol',
+  'roadmapcol-description': 'A roadmap for Colombia',
+  github: 'GitHub',
+  linkedin: 'LinkedIn',
+  email: 'Email',
+  location: 'Location',
+  'frontend-developer': 'Frontend Developer',
+  'frontend-developer-freelance': 'Frontend Developer Freelance',
+  'aleluya-description': 'Worked at Aleluya on payroll features',
+  'aleluya-freelance-description': 'Freelance at Aleluya',
+  'january-2025': 'January 2025',
+  'august-2024': 'August 2024',
+  'december-2024': 'December 2024',
+  current: 'Current',
+  code: 'Code',
+  'live-demo': 'Live Demo',
+}
+
+mock.module('@/app/[lang]/dictionaries/client', () => ({
+  getClientDictionary: () => MOCK_DICT,
+}))
+
+afterEach(() => cleanup())
+
+const { BlogCard } = await import('@/components/cards/blog-card')
+const { ProjectCard } = await import('@/components/cards/project-card')
+const { ContactCard } = await import('@/components/cards/contact-card')
+const { ExperienceCard } = await import('@/components/cards/experience-card')
+
+// ─── BlogCard ────────────────────────────────────────────────────────────────
+
+describe('BlogCard', () => {
+  const post = {
+    url: 'my-post',
+    title: 'My First Post',
+    short_title: 'First Post',
+    date: '2025-01-01',
+    description: 'A great post',
+    image: '/images/post.jpg',
+  }
+
+  test('renders the post title', () => {
+    render(<BlogCard post={post} />)
+    expect(screen.getByText('My First Post')).toBeDefined()
+  })
+
+  test('link points to /{lang}/blog/{url}', () => {
+    render(<BlogCard post={post} />)
+    const link = screen.getByRole('link')
+    expect(link.getAttribute('href')).toBe('/en/blog/my-post')
+  })
+
+  test('image has correct alt text', () => {
+    render(<BlogCard post={post} />)
+    const img = screen.getByAltText('My First Post')
+    expect(img).toBeDefined()
+  })
+})
+
+// ─── ProjectCard ─────────────────────────────────────────────────────────────
+
+describe('ProjectCard', () => {
+  const project = {
+    name: 'roadmapcol',
+    description: 'roadmapcol-description',
+    stack: ['Next.js', 'Tailwind'],
+    link: 'https://roadmapcol.com',
+    repo: 'https://github.com/LEstebanR/roadmapcol',
+  }
+
+  test('renders the translated project name', () => {
+    render(<ProjectCard project={project} />)
+    expect(screen.getByText('Roadmapcol')).toBeDefined()
+  })
+
+  test('renders all stack badges', () => {
+    render(<ProjectCard project={project} />)
+    expect(screen.getByText('Next.js')).toBeDefined()
+    expect(screen.getByText('Tailwind')).toBeDefined()
+  })
+
+  test('shows repo link when repo is defined', () => {
+    render(<ProjectCard project={project} />)
+    expect(screen.getByText('Code')).toBeDefined()
+  })
+
+  test('shows live demo link when link is defined', () => {
+    render(<ProjectCard project={project} />)
+    expect(screen.getByText('Live Demo')).toBeDefined()
+  })
+
+  test('does not show repo link when repo is undefined', () => {
+    render(<ProjectCard project={{ ...project, repo: undefined }} />)
+    expect(screen.queryByText('Code')).toBeNull()
+  })
+
+  test('does not show live demo link when link is undefined', () => {
+    render(<ProjectCard project={{ ...project, link: undefined }} />)
+    expect(screen.queryByText('Live Demo')).toBeNull()
+  })
+})
+
+// ─── ContactCard ─────────────────────────────────────────────────────────────
+
+describe('ContactCard', () => {
+  const githubLink = {
+    label: 'github',
+    href: 'https://github.com/LEstebanR',
+    user: 'LEstebanR',
+    icon: '/logos/github_light.svg',
+    iconColor: '',
+  }
+
+  const locationLink = {
+    label: 'location',
+    href: '#',
+    user: 'Colombia',
+    icon: '/logos/location_light.svg',
+    iconColor: '',
+  }
+
+  test('renders the translated label', () => {
+    render(<ContactCard link={githubLink} />)
+    expect(screen.getByText('GitHub')).toBeDefined()
+  })
+
+  test('renders the user handle', () => {
+    render(<ContactCard link={githubLink} />)
+    expect(screen.getByText('LEstebanR')).toBeDefined()
+  })
+
+  test('external link has correct href', () => {
+    render(<ContactCard link={githubLink} />)
+    const link = screen.getByRole('link')
+    expect(link.getAttribute('href')).toBe('https://github.com/LEstebanR')
+  })
+
+  test('external link opens in _blank', () => {
+    render(<ContactCard link={githubLink} />)
+    const link = screen.getByRole('link')
+    expect(link.getAttribute('target')).toBe('_blank')
+  })
+
+  test('location link with href="#" opens in _self', () => {
+    render(<ContactCard link={locationLink} />)
+    const link = screen.getByRole('link')
+    expect(link.getAttribute('target')).toBe('_self')
+  })
+})
+
+// ─── ExperienceCard ──────────────────────────────────────────────────────────
+
+describe('ExperienceCard', () => {
+  const job = {
+    position: 'frontend-developer',
+    company: 'Aleluya',
+    description: 'aleluya-description',
+    startDate: 'january-2025',
+    endDate: 'current',
+    stack: ['React', 'MUI', 'Cypress'],
+  }
+
+  test('renders the translated position', () => {
+    render(<ExperienceCard job={job} />)
+    expect(screen.getByText('Frontend Developer')).toBeDefined()
+  })
+
+  test('renders the company name', () => {
+    render(<ExperienceCard job={job} />)
+    expect(screen.getByText('Aleluya')).toBeDefined()
+  })
+
+  test('renders all stack badges', () => {
+    render(<ExperienceCard job={job} />)
+    expect(screen.getByText('React')).toBeDefined()
+    expect(screen.getByText('MUI')).toBeDefined()
+    expect(screen.getByText('Cypress')).toBeDefined()
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+GlobalRegistrator.register()

--- a/tests/smoke.test.tsx
+++ b/tests/smoke.test.tsx
@@ -1,0 +1,7 @@
+import { expect, test } from 'bun:test'
+import { render } from '@testing-library/react'
+
+test('React Testing Library renders correctly', () => {
+  const { getByText } = render(<div>hello</div>)
+  expect(getByText('hello')).toBeDefined()
+})


### PR DESCRIPTION
## Summary

- **Design system:** Replaced all hardcoded colors (`border-gray-*`, `text-slate-500`, `fill-red-500`) with semantic design tokens; applied `font-heading` consistently to all headings and `CardTitle`; replaced `animate-bounce` icons with `hover:scale-110` transitions; replaced `hover:shadow-lg` in BlogCard with tonal border elevation; added visual card container to ExperienceCard entries.
- **Tests:** Bootstrapped a full unit test suite (61 tests, 0 failures) using `bun:test` + React Testing Library + happy-dom. Covers `lib/utils.ts`, `middleware.ts`, `lib/blog.ts` (extended), and all four card components (BlogCard, ProjectCard, ContactCard, ExperienceCard).
- **CI:** Added `.github/workflows/test.yml` to run `bun test` on every PR.
- **Tooling:** Added `CLAUDE.md`, `DESIGN.md`, and six Claude Code slash commands (`/commit`, `/component`, `/blog-post`, `/linear-issue`, `/create-pr`, `/retrospective`).

## Linear issues

- Closes LES-37, LES-38, LES-39, LES-40, LES-41, LES-42
- Closes LES-43, LES-44, LES-45, LES-46, LES-47

## Test plan

- [ ] `bun test` passes locally (61/61)
- [ ] `bun typecheck` passes with no errors
- [ ] `bun lint` passes with no warnings
- [ ] GitHub Actions `Test` workflow runs green on this PR
- [ ] Section headings render in Space Grotesk (font-heading) in both light and dark mode
- [ ] Skills icons animate on hover only (no continuous bounce)
- [ ] BlogCard hover changes border color, not shadow
- [ ] ExperienceCard entries each have a visible card border
- [ ] Header border adapts correctly in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)