### PR TITLE
refac(i18n): Add useLang() hook and replace inline lang detection

### DIFF
--- a/app/[lang]/blog/error.tsx
+++ b/app/[lang]/blog/error.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect } from 'react'
 
-import { usePathname } from 'next/navigation'
-
 import { Button } from '@/components/ui/button'
 import { Link } from '@/components/ui/link'
+
+import { useLang } from '@/hooks/use-lang'
 
 export default function BlogError({
   error,
@@ -14,8 +14,7 @@ export default function BlogError({
   error: Error & { digest?: string }
   reset: () => void
 }) {
-  const pathname = usePathname()
-  const lang = pathname.split('/')[1] as 'en' | 'es'
+  const lang = useLang()
 
   useEffect(() => {
     // Log the error to an error reporting service

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -1,16 +1,15 @@
 'use client'
 
-import { usePathname } from 'next/navigation'
-
 import { Contact } from '@/components/contact'
 import { Experience } from '@/components/experience'
 import { Hero } from '@/components/hero'
 import { Projects } from '@/components/projects'
 import { Skills } from '@/components/skills'
 
+import { useLang } from '@/hooks/use-lang'
+
 export default function Home() {
-  const pathname = usePathname()
-  const lang = pathname.split('/')[1] as 'en' | 'es'
+  const lang = useLang()
   return (
     <div className="flex flex-col gap-12">
       <Hero lang={lang} />

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "lesteban-next",

--- a/components/cards/blog-card.tsx
+++ b/components/cards/blog-card.tsx
@@ -2,7 +2,8 @@
 
 import Image from 'next/image'
 import NextLink from 'next/link'
-import { usePathname } from 'next/navigation'
+
+import { useLang } from '@/hooks/use-lang'
 
 import { Card, CardHeader, CardTitle } from '@/components/ui/card'
 
@@ -16,8 +17,7 @@ type BlogPost = {
 }
 
 export function BlogCard({ post }: { post: BlogPost }) {
-  const pathname = usePathname()
-  const lang = pathname.split('/')[1] as 'en' | 'es'
+  const lang = useLang()
 
   return (
     <NextLink href={`/${lang}/blog/${post.url}`}>

--- a/components/cards/contact-card.tsx
+++ b/components/cards/contact-card.tsx
@@ -4,7 +4,8 @@ import { getClientDictionary } from '@/app/[lang]/dictionaries/client'
 
 import Image from 'next/image'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+
+import { useLang } from '@/hooks/use-lang'
 
 import {
   Card,
@@ -22,8 +23,7 @@ export type ContactLink = {
 }
 
 export function ContactCard({ link }: { link: ContactLink }) {
-  const pathname = usePathname()
-  const lang = pathname.split('/')[1] as 'en' | 'es'
+  const lang = useLang()
   const dictionary = getClientDictionary(lang)
   return (
     <Link href={link.href} target={link.href === '#' ? '_self' : '_blank'}>

--- a/components/cards/experience-card.tsx
+++ b/components/cards/experience-card.tsx
@@ -2,9 +2,9 @@
 
 import { getClientDictionary } from '@/app/[lang]/dictionaries/client'
 
-import { usePathname } from 'next/navigation'
-
 import { Calendar, Code } from 'lucide-react'
+
+import { useLang } from '@/hooks/use-lang'
 
 import { Badge } from '@/components/ui/badge'
 
@@ -18,8 +18,7 @@ export type ExperienceType = {
 }
 
 export function ExperienceCard({ job }: { job: ExperienceType }) {
-  const pathname = usePathname()
-  const lang = pathname.split('/')[1] as 'en' | 'es'
+  const lang = useLang()
   const dictionary = getClientDictionary(lang)
   return (
     <div className="bg-card border-border flex flex-col gap-2 rounded-lg border p-4">

--- a/components/cards/project-card.tsx
+++ b/components/cards/project-card.tsx
@@ -3,13 +3,13 @@
 import { getClientDictionary } from '@/app/[lang]/dictionaries/client'
 
 import Image from 'next/image'
-import { usePathname } from 'next/navigation'
 
 import { useTheme } from 'next-themes'
 
 import { ExternalLink } from 'lucide-react'
 
 import { useHasMounted } from '@/hooks/use-has-mounted'
+import { useLang } from '@/hooks/use-lang'
 
 import { Badge } from '@/components/ui/badge'
 import {
@@ -29,8 +29,7 @@ type Project = {
   repo?: string
 }
 export function ProjectCard({ project }: { project: Project }) {
-  const pathname = usePathname()
-  const lang = pathname.split('/')[1] as 'en' | 'es'
+  const lang = useLang()
   const dictionary = getClientDictionary(lang)
   const { resolvedTheme } = useTheme()
   const mounted = useHasMounted()

--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -2,17 +2,15 @@
 
 import { getClientDictionary } from '@/app/[lang]/dictionaries/client'
 
-import { usePathname } from 'next/navigation'
-
 import { useTheme } from 'next-themes'
 
 import { useHasMounted } from '@/hooks/use-has-mounted'
+import { useLang } from '@/hooks/use-lang'
 
 import { ContactCard, ContactLink } from '@/components/cards/contact-card'
 
 export function Contact() {
-  const pathname = usePathname()
-  const lang = pathname.split('/')[1] as 'en' | 'es'
+  const lang = useLang()
   const dictionary = getClientDictionary(lang)
   const { resolvedTheme } = useTheme()
   const mounted = useHasMounted()

--- a/components/experience.tsx
+++ b/components/experience.tsx
@@ -2,7 +2,7 @@
 
 import { getClientDictionary } from '@/app/[lang]/dictionaries/client'
 
-import { usePathname } from 'next/navigation'
+import { useLang } from '@/hooks/use-lang'
 
 import { ExperienceCard } from '@/components/cards/experience-card'
 import { SeeMoreButton } from '@/components/ui/see-more-button'
@@ -43,8 +43,7 @@ const EXPERIENCE = {
 }
 
 export function Experience() {
-  const pathname = usePathname()
-  const lang = pathname.split('/')[1] as 'en' | 'es'
+  const lang = useLang()
   const dictionary = getClientDictionary(lang)
 
   return (

--- a/components/projects.tsx
+++ b/components/projects.tsx
@@ -2,7 +2,7 @@
 
 import { getClientDictionary } from '@/app/[lang]/dictionaries/client'
 
-import { usePathname } from 'next/navigation'
+import { useLang } from '@/hooks/use-lang'
 
 import { ProjectCard } from '@/components/cards/project-card'
 
@@ -38,8 +38,7 @@ const PROJECTS = [
 ]
 
 export function Projects() {
-  const pathname = usePathname()
-  const lang = pathname.split('/')[1] as 'en' | 'es'
+  const lang = useLang()
   const dictionary = getClientDictionary(lang)
   return (
     <div className="flex flex-col gap-4">

--- a/components/skills.tsx
+++ b/components/skills.tsx
@@ -2,9 +2,9 @@
 
 import { getClientDictionary } from '@/app/[lang]/dictionaries/client'
 
-import { usePathname } from 'next/navigation'
-
 import { Code, Database, Layout, Server } from 'lucide-react'
+
+import { useLang } from '@/hooks/use-lang'
 
 import { Badge } from '@/components/ui/badge'
 
@@ -48,8 +48,7 @@ function Skill({
 }
 
 export function Skills() {
-  const pathname = usePathname()
-  const lang = pathname.split('/')[1] as 'en' | 'es'
+  const lang = useLang()
   const dictionary = getClientDictionary(lang)
   return (
     <div className="flex flex-col gap-4">

--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -4,13 +4,13 @@ import { getClientDictionary } from '@/app/[lang]/dictionaries/client'
 import { motion } from 'framer-motion'
 
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
 
 import { Heart } from 'lucide-react'
 
+import { useLang } from '@/hooks/use-lang'
+
 export function Footer() {
-  const pathname = usePathname()
-  const lang = pathname.split('/')[1] as 'en' | 'es'
+  const lang = useLang()
   const dictionary = getClientDictionary(lang)
 
   return (

--- a/hooks/use-lang.ts
+++ b/hooks/use-lang.ts
@@ -1,0 +1,7 @@
+import { usePathname } from 'next/navigation'
+
+export function useLang(): 'en' | 'es' {
+  const pathname = usePathname()
+  const segment = pathname.split('/')[1]
+  return segment === 'es' ? 'es' : 'en'
+}


### PR DESCRIPTION
## Context

The pattern `pathname.split('/')[1] as 'en' | 'es'` was duplicated across 11 client components. Centralizing it into a single hook makes the codebase easier to maintain and provides a single place to update if a third locale is added in the future.

## Changes

- **`hooks/use-lang.ts`** — new hook that wraps `usePathname()` and returns the active locale (`'en' | 'es'`), replacing all inline occurrences
- **`app/[lang]/page.tsx`** — replaced inline pattern with `useLang()`
- **`app/[lang]/blog/error.tsx`** — replaced inline pattern with `useLang()`
- **`components/contact.tsx`** — replaced inline pattern with `useLang()`
- **`components/experience.tsx`** — replaced inline pattern with `useLang()`
- **`components/projects.tsx`** — replaced inline pattern with `useLang()`
- **`components/skills.tsx`** — replaced inline pattern with `useLang()`
- **`components/ui/footer.tsx`** — replaced inline pattern with `useLang()`
- **`components/cards/blog-card.tsx`** — replaced inline pattern with `useLang()`
- **`components/cards/contact-card.tsx`** — replaced inline pattern with `useLang()`
- **`components/cards/experience-card.tsx`** — replaced inline pattern with `useLang()`
- **`components/cards/project-card.tsx`** — replaced inline pattern with `useLang()`

## Linear issues

- Closes LES-52

## Test plan

- [ ] Navigate to `/en` — all sections (Hero, Experience, Skills, Projects, Contact, Footer) render English content
- [ ] Navigate to `/es` — all sections render Spanish content
- [ ] Switch language via the language toggle — page re-renders in the correct locale without errors
- [ ] Blog card links point to the correct locale prefix (e.g. `/es/blog/...`)
- [ ] `bun typecheck` passes (no new errors introduced)
- [ ] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7KB3y5AWQgBe8b4VAYJmt)_