### PR TITLE
fix(ui): A11y — aria-hidden en ScrollProgress y nav landmarks en Header

### DIFF
--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -77,7 +77,10 @@ export function Header() {
   }
 
   return (
-    <header className="bg-background fixed top-0 right-0 left-0 z-10 flex h-16 w-full items-center border-b border-border py-1">
+    <header
+      aria-label={currentLang === 'es' ? 'Encabezado del sitio' : 'Site header'}
+      className="bg-background fixed top-0 right-0 left-0 z-10 flex h-16 w-full items-center border-b border-border py-1"
+    >
       <div className="flex w-full items-center justify-between">
         <div className="md:flex-1" />
         <div className="flex w-full items-center justify-between px-2 md:px-4 lg:w-3/6 lg:px-0 2xl:w-2/6">
@@ -87,7 +90,10 @@ export function Header() {
             </h1>
           </Link>
           {isHome ? (
-            <div className="hidden w-1/2 flex-wrap items-center justify-end gap-2 px-1 md:flex md:px-0">
+            <nav
+              aria-label={currentLang === 'es' ? 'Navegación principal' : 'Main navigation'}
+              className="hidden w-1/2 flex-wrap items-center justify-end gap-2 px-1 md:flex md:px-0"
+            >
               <NextLink
                 href={`/${currentLang}/blog`}
                 className="hover:text-primary hover:animate-underline-link flex items-center gap-1.5 decoration-2 underline-offset-4 transition-all duration-300 hover:underline"
@@ -95,7 +101,7 @@ export function Header() {
                 <BookOpen className="h-4 w-4" />
                 Blog
               </NextLink>
-            </div>
+            </nav>
           ) : (
             <div className="hidden w-1/2 items-center justify-end px-1 md:flex md:px-0">
               <Breadcrumb>

--- a/components/ui/scroll-progress.tsx
+++ b/components/ui/scroll-progress.tsx
@@ -34,6 +34,7 @@ export function ScrollProgress({
 
   return (
     <motion.div
+      aria-hidden="true"
       className={cn('inset-x-0 top-0 h-1 origin-left', className)}
       style={{
         scaleX,


### PR DESCRIPTION
## Summary

Resuelve [LES-55](https://linear.app/lesteban/issue/LES-55/a11y-aria-hidden-en-scroll-progress-y-mejoras-de-landmarks) — dos problemas de accesibilidad reportados.

- **ScrollProgress**: Agrega `aria-hidden="true"` al elemento decorativo de barra de progreso para que los lectores de pantalla lo omitan completamente.
- **Header landmarks**: Convierte el `<div>` de navegación desktop en `<nav aria-label="Main navigation / Navegación principal">` (bilingüe según `currentLang`).
- **Header label**: Agrega `aria-label` al elemento `<header>` para identificar la región correctamente en lectores de pantalla.

> El componente `<Breadcrumb>` ya renderea `<nav aria-label="breadcrumb">` internamente, por lo que esa ruta queda cubierta sin cambios adicionales.

## Test plan

- [ ] Verificar con VoiceOver/NVDA que la barra de scroll progress no se anuncia al navegar la página
- [ ] Verificar que la región `<header>` es identificada como landmark de encabezado
- [ ] Verificar que los links de navegación desktop (Blog) están dentro de un landmark `<nav>` con label descriptivo
- [ ] Confirmar que el breadcrumb sigue funcionando correctamente en páginas internas
- [ ] Revisar en modo dark y light que no hay regresiones visuales

https://claude.ai/code/session_01V6XSXTvBimKoLgjWja8hGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6XSXTvBimKoLgjWja8hGR)_