### PR TITLE
refac(portfolio): Extract static data to lib/data.ts

### DIFF
--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -8,6 +8,7 @@ import { useHasMounted } from '@/hooks/use-has-mounted'
 import { useLang } from '@/hooks/use-lang'
 
 import { ContactCard, ContactLink } from '@/components/cards/contact-card'
+import { resolveContactLinks } from '@/lib/data'
 
 export function Contact() {
   const lang = useLang()
@@ -15,41 +16,7 @@ export function Contact() {
   const { resolvedTheme } = useTheme()
   const mounted = useHasMounted()
 
-  const CONTACT_LINKS = mounted
-    ? [
-        {
-          label: 'github',
-          href: 'https://github.com/LEstebanR',
-          user: 'LEstebanR',
-          icon:
-            resolvedTheme === 'dark'
-              ? '/logos/github_dark.svg'
-              : '/logos/github_light.svg',
-        },
-        {
-          label: 'linkedin',
-          href: 'https://www.linkedin.com/in/lestebanr/',
-          user: 'Luis Esteban',
-          icon: '/logos/linkedin.svg',
-        },
-        {
-          label: 'email',
-          href: 'mailto:leramirezca@gmail.com',
-          user: 'leramirezca@gmail.com',
-          icon:
-            resolvedTheme === 'dark' ? '/logos/mail_dark.svg' : '/logos/mail_light.svg',
-        },
-        {
-          label: 'location',
-          user: 'Colombia',
-          icon:
-            resolvedTheme === 'dark'
-              ? '/logos/location_dark.svg'
-              : '/logos/location_light.svg',
-          href: '#',
-        },
-      ]
-    : []
+  const CONTACT_LINKS = mounted ? resolveContactLinks(resolvedTheme === 'dark') : []
   if (!mounted) {
     return (
       <div className="flex flex-col gap-4">

--- a/components/experience.tsx
+++ b/components/experience.tsx
@@ -6,41 +6,7 @@ import { useLang } from '@/hooks/use-lang'
 
 import { ExperienceCard } from '@/components/cards/experience-card'
 import { SeeMoreButton } from '@/components/ui/see-more-button'
-
-const EXPERIENCE = {
-  aleluya: {
-    position: 'frontend-developer',
-    company: 'Aleluya',
-    description: 'aleluya-description',
-    startDate: 'january-2025',
-    endDate: 'current',
-    stack: ['React', 'MUI', 'React-Query', 'Cypress'],
-  },
-  aleluya_freelance: {
-    position: 'frontend-developer-freelance',
-    company: 'Aleluya',
-    description: 'aleluya-freelance-description',
-    startDate: 'august-2024',
-    endDate: 'december-2024',
-    stack: ['React', 'MUI', 'React-Query', 'Cypress'],
-  },
-  devpeoplz: {
-    position: 'fullstack-developer',
-    company: 'DevPeoplz',
-    description: 'devpeoplz-description',
-    startDate: 'november-2022',
-    endDate: 'january-2024',
-    stack: ['Next.js', 'Typescript', 'Tailwind', 'Supabase'],
-  },
-  nominapp: {
-    position: 'frontend-developer',
-    company: 'Nominapp',
-    description: 'nominapp-description',
-    startDate: 'april-2022',
-    endDate: 'november-2022',
-    stack: ['React', 'MUI', 'React-Query', 'Cypress'],
-  },
-}
+import { EXPERIENCE } from '@/lib/data'
 
 export function Experience() {
   const lang = useLang()

--- a/components/projects.tsx
+++ b/components/projects.tsx
@@ -5,37 +5,7 @@ import { getClientDictionary } from '@/app/[lang]/dictionaries/client'
 import { useLang } from '@/hooks/use-lang'
 
 import { ProjectCard } from '@/components/cards/project-card'
-
-const PROJECTS = [
-  {
-    name: 'roadmapcol',
-    description: 'roadmapcol-description',
-    stack: ['Next.js', 'Tailwind', 'Shadcn'],
-    link: 'https://roadmapcol.com/',
-    repo: 'https://github.com/LEstebanR/roadmapcol',
-  },
-  {
-    name: 'oniricapp',
-    description: 'oniricapp-description',
-    stack: ['Next.js', 'Tailwind', 'Llama'],
-    link: 'https://www.oniricapp.com/',
-    repo: 'https://github.com/LEstebanR/dream_Interpreter',
-  },
-  {
-    name: 'kodempro',
-    description: 'kodempro-description',
-    stack: ['Next.js', 'Tailwind', 'Shadcn'],
-    link: 'https://kodempro.com/',
-    repo: 'https://github.com/LEstebanR/kodempro',
-  },
-  {
-    name: 'humedad-arena',
-    description: 'humedad-arena-description',
-    stack: ['React', 'Typescript', 'Tailwind'],
-    link: 'https://humedad-arena.vercel.app/',
-    repo: 'https://github.com/LEstebanR/humedad_arena',
-  },
-]
+import { PROJECTS } from '@/lib/data'
 
 export function Projects() {
   const lang = useLang()

--- a/components/skills.tsx
+++ b/components/skills.tsx
@@ -7,13 +7,7 @@ import { Code, Database, Layout, Server } from 'lucide-react'
 import { useLang } from '@/hooks/use-lang'
 
 import { Badge } from '@/components/ui/badge'
-
-const SKILLS = {
-  frontend: ['React', 'Next', 'Tailwind'],
-  backend: ['Node.js', 'Supabase'],
-  database: ['MongoDB', 'PostgresSQL'],
-  programing_languages: ['Javascript', 'Typescript'],
-}
+import { SKILLS } from '@/lib/data'
 
 function Skill({
   skill,

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,129 @@
+import { ExperienceType } from '@/components/cards/experience-card'
+import { ContactLink } from '@/components/cards/contact-card'
+
+export type Project = {
+  name: string
+  description: string
+  stack: string[]
+  link?: string
+  repo?: string
+}
+
+export type Skills = {
+  frontend: string[]
+  backend: string[]
+  database: string[]
+  programing_languages: string[]
+}
+
+export const EXPERIENCE: Record<string, ExperienceType> = {
+  aleluya: {
+    position: 'frontend-developer',
+    company: 'Aleluya',
+    description: 'aleluya-description',
+    startDate: 'january-2025',
+    endDate: 'current',
+    stack: ['React', 'MUI', 'React-Query', 'Cypress'],
+  },
+  aleluya_freelance: {
+    position: 'frontend-developer-freelance',
+    company: 'Aleluya',
+    description: 'aleluya-freelance-description',
+    startDate: 'august-2024',
+    endDate: 'december-2024',
+    stack: ['React', 'MUI', 'React-Query', 'Cypress'],
+  },
+  devpeoplz: {
+    position: 'fullstack-developer',
+    company: 'DevPeoplz',
+    description: 'devpeoplz-description',
+    startDate: 'november-2022',
+    endDate: 'january-2024',
+    stack: ['Next.js', 'Typescript', 'Tailwind', 'Supabase'],
+  },
+  nominapp: {
+    position: 'frontend-developer',
+    company: 'Nominapp',
+    description: 'nominapp-description',
+    startDate: 'april-2022',
+    endDate: 'november-2022',
+    stack: ['React', 'MUI', 'React-Query', 'Cypress'],
+  },
+}
+
+export const PROJECTS: Project[] = [
+  {
+    name: 'roadmapcol',
+    description: 'roadmapcol-description',
+    stack: ['Next.js', 'Tailwind', 'Shadcn'],
+    link: 'https://roadmapcol.com/',
+    repo: 'https://github.com/LEstebanR/roadmapcol',
+  },
+  {
+    name: 'oniricapp',
+    description: 'oniricapp-description',
+    stack: ['Next.js', 'Tailwind', 'Llama'],
+    link: 'https://www.oniricapp.com/',
+    repo: 'https://github.com/LEstebanR/dream_Interpreter',
+  },
+  {
+    name: 'kodempro',
+    description: 'kodempro-description',
+    stack: ['Next.js', 'Tailwind', 'Shadcn'],
+    link: 'https://kodempro.com/',
+    repo: 'https://github.com/LEstebanR/kodempro',
+  },
+  {
+    name: 'humedad-arena',
+    description: 'humedad-arena-description',
+    stack: ['React', 'Typescript', 'Tailwind'],
+    link: 'https://humedad-arena.vercel.app/',
+    repo: 'https://github.com/LEstebanR/humedad_arena',
+  },
+]
+
+export const SKILLS: Skills = {
+  frontend: ['React', 'Next', 'Tailwind'],
+  backend: ['Node.js', 'Supabase'],
+  database: ['MongoDB', 'PostgresSQL'],
+  programing_languages: ['Javascript', 'Typescript'],
+}
+
+export const CONTACT_LINKS_STATIC = [
+  {
+    label: 'github',
+    href: 'https://github.com/LEstebanR',
+    user: 'LEstebanR',
+    lightIcon: '/logos/github_light.svg',
+    darkIcon: '/logos/github_dark.svg',
+  },
+  {
+    label: 'linkedin',
+    href: 'https://www.linkedin.com/in/lestebanr/',
+    user: 'Luis Esteban',
+    lightIcon: '/logos/linkedin.svg',
+    darkIcon: '/logos/linkedin.svg',
+  },
+  {
+    label: 'email',
+    href: 'mailto:leramirezca@gmail.com',
+    user: 'leramirezca@gmail.com',
+    lightIcon: '/logos/mail_light.svg',
+    darkIcon: '/logos/mail_dark.svg',
+  },
+  {
+    label: 'location',
+    href: '#',
+    user: 'Colombia',
+    lightIcon: '/logos/location_light.svg',
+    darkIcon: '/logos/location_dark.svg',
+  },
+]
+
+export function resolveContactLinks(isDark: boolean): ContactLink[] {
+  return CONTACT_LINKS_STATIC.map(({ lightIcon, darkIcon, ...rest }) => ({
+    ...rest,
+    icon: isDark ? darkIcon : lightIcon,
+    iconColor: '',
+  }))
+}


### PR DESCRIPTION
## Summary

- Crea `lib/data.ts` con todos los datos del portafolio tipados: `EXPERIENCE`, `PROJECTS`, `SKILLS`, `CONTACT_LINKS_STATIC` y `resolveContactLinks`
- Elimina los datos hardcodeados de `components/experience.tsx`, `components/projects.tsx`, `components/skills.tsx` y `components/contact.tsx`
- Los componentes ahora solo importan y renderizan — actualizar el contenido del portafolio es editar un único archivo

## Test plan

- [ ] Verificar que la sección Experience renderiza correctamente en `/en` y `/es`
- [ ] Verificar que la sección Projects renderiza los 4 proyectos con links y repos
- [ ] Verificar que la sección Skills muestra las 4 categorías correctamente
- [ ] Verificar que la sección Contact muestra los íconos correctos en modo claro y oscuro
- [ ] Confirmar que no hay regresiones en el resto de la página

Closes LES-53

https://claude.ai/code/session_01JXYmQT9Y2hvoG4BuHKF1hq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXYmQT9Y2hvoG4BuHKF1hq)_