### PR TITLE
fix(ui): Add visible focus ring to Link component for keyboard navigation

### DIFF
--- a/components/ui/link.tsx
+++ b/components/ui/link.tsx
@@ -1,23 +1,31 @@
 import { default as NextLink } from 'next/link'
 
+import { cn } from '@/lib/utils'
+
 export function Link({
   children,
   href,
   withIcon = false,
   icon,
   target = '_blank',
+  className,
 }: {
   children: React.ReactNode
   href: string
   withIcon?: boolean
   icon?: React.ReactNode
   target?: string
+  className?: string
 }) {
   return (
     <NextLink
       href={href}
       target={target}
-      className="hover:text-primary hover:animate-underline-link decoration-2 underline-offset-4 transition-all duration-300 hover:underline"
+      className={cn(
+        'hover:text-primary hover:animate-underline-link decoration-2 underline-offset-4 transition-all duration-300 hover:underline',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm',
+        className
+      )}
     >
       <div className="flex flex-row items-center gap-1">
         {withIcon && icon}


### PR DESCRIPTION
## Summary

- Adds `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm` classes to the `NextLink` element in `components/ui/link.tsx`
- Accepts an optional `className` prop for ad-hoc overrides
- Consistent with the focus ring pattern already used in `components/ui/button.tsx`

## Motivation

The `Link` component wrapped content in a `<div>` that blocked the native `<a>` outline, leaving keyboard users without a visible focus indicator.

## Test plan

- [ ] Tab through the page using keyboard and verify the Link component shows a visible focus ring
- [ ] Verify the ring uses the `--ring` design token (consistent with other interactive elements)
- [ ] Verify dark mode — ring should be visible on both light and dark backgrounds
- [ ] Verify no visual regression on hover/active states

Closes LES-54

https://claude.ai/code/session_01Mpv2mSbycaTEvSyZdJLtme

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mpv2mSbycaTEvSyZdJLtme)_