### PR TITLE
feat(seo): add RSS feed for the blog (LES-56)

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -142,6 +142,12 @@ export default async function RootLayout({
           name="keywords"
           content="Desarrollador web, Next.js, React, Portafolio, Esteban, Luis Esteban Ramirez, lesteban, developer, frontend, backend, fullstack, software, developer, developer web, developer frontend, developer backend, developer fullstack, developer software, developer web, developer frontend, developer backend, developer fullstack, developer software"
         />
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title="Luis Esteban — Blog"
+          href="/feed.xml"
+        />
       </head>
       <body
         className={`${inter.variable} ${bricolageGrotesque.variable} ${jetbrainsMono.variable} flex min-h-screen flex-col`}

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,0 +1,45 @@
+import { getAllPosts } from '@/lib/blog'
+
+const BASE_URL = 'https://lesteban.dev'
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+export async function GET() {
+  const posts = await getAllPosts('en')
+
+  const items = posts
+    .map(
+      (p) => `
+    <item>
+      <title>${escapeXml(p.title)}</title>
+      <link>${BASE_URL}/en/blog/${p.url}</link>
+      <guid>${BASE_URL}/en/blog/${p.url}</guid>
+      <pubDate>${new Date(p.date).toUTCString()}</pubDate>
+      <description>${escapeXml(p.description)}</description>
+    </item>`
+    )
+    .join('')
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Luis Esteban — Blog</title>
+    <link>${BASE_URL}/en/blog</link>
+    <description>Articles on software development by Luis Esteban Ramirez.</description>
+    <language>en</language>
+    <atom:link href="${BASE_URL}/feed.xml" rel="self" type="application/rss+xml" />
+    ${items}
+  </channel>
+</rss>`
+
+  return new Response(xml, {
+    headers: { 'Content-Type': 'application/xml; charset=utf-8' },
+  })
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Creates `app/feed.xml/route.ts` with a proper RSS 2.0 handler that serves all English blog posts
- Includes XML escaping for title and description fields to avoid malformed XML
- Adds `atom:link` self-reference and `<guid>` per item for full RSS 2.0 compliance
- Adds `<link rel="alternate" type="application/rss+xml">` in the `[lang]/layout.tsx` head to advertise the feed to browsers and RSS readers

## Test plan

- [ ] Visit `/feed.xml` — should return valid XML with `Content-Type: application/xml`
- [ ] Validate the feed in an RSS reader or validator (e.g. validator.w3.org/feed)
- [ ] Confirm the `<link>` tag appears in the page `<head>` (inspect element on any page)

Closes LES-56

https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8)_