### PR TITLE
feat(blog): add related posts component (LES-67)

### DIFF
--- a/app/[lang]/blog/[name]/page.tsx
+++ b/app/[lang]/blog/[name]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 
 import { Calendar } from 'lucide-react'
 
+import { RelatedPosts } from '@/components/related-posts'
 import { SetBreadcrumb } from '@/components/set-breadcrumb'
 import { Badge } from '@/components/ui/badge'
 import { ScrollProgress } from '@/components/ui/scroll-progress'
@@ -154,6 +155,7 @@ export default async function BlogPostPage({ params }: PageParams) {
           className="blog-content animate-fade-in-up [animation-delay:200ms] [animation-fill-mode:both]"
           dangerouslySetInnerHTML={{ __html: post.content || '' }}
         />
+        <RelatedPosts currentUrl={post.url} lang={lang} />
       </div>
     </>
   )

--- a/app/[lang]/dictionaries/en.json
+++ b/app/[lang]/dictionaries/en.json
@@ -47,5 +47,6 @@
   "blog": "Blog",
   "no-posts": "No posts yet",
   "made-with": "Made with",
-  "by": "by"
+  "by": "by",
+  "related-posts": "Related posts"
 }

--- a/app/[lang]/dictionaries/es.json
+++ b/app/[lang]/dictionaries/es.json
@@ -47,5 +47,6 @@
   "blog": "Blog",
   "no-posts": "Aún no hay entradas",
   "made-with": "Hecho con",
-  "by": "por"
+  "by": "por",
+  "related-posts": "Posts relacionados"
 }

--- a/components/related-posts.tsx
+++ b/components/related-posts.tsx
@@ -1,0 +1,35 @@
+import { getDictionary } from '@/app/[lang]/dictionaries'
+
+import { BlogCard } from '@/components/cards/blog-card'
+
+import { getAllPosts } from '@/lib/blog'
+
+interface RelatedPostsProps {
+  currentUrl: string
+  lang: 'en' | 'es'
+}
+
+export async function RelatedPosts({ currentUrl, lang }: RelatedPostsProps) {
+  const [allPosts, dictionary] = await Promise.all([
+    getAllPosts(lang),
+    getDictionary(lang),
+  ])
+
+  const related = allPosts.filter((p) => p.url !== currentUrl).slice(0, 2)
+
+  if (related.length < 2) return null
+
+  return (
+    <section className="flex flex-col gap-6">
+      <div className="border-border via-border h-px w-full bg-gradient-to-r from-transparent to-transparent" />
+      <h2 className="font-heading text-foreground text-2xl font-bold">
+        {dictionary['related-posts']}
+      </h2>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        {related.map((post) => (
+          <BlogCard key={post.url} post={post} />
+        ))}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

- Creates `components/related-posts.tsx` as a server component
- Receives `currentUrl` and `lang` as props; calls `getAllPosts(lang)`, filters the current post, and takes the 2 most recent
- Renders 2 `BlogCard` in a `md:grid-cols-2` grid with a section divider and heading
- Returns `null` when fewer than 2 posts are available (conditional rendering)
- Adds `"related-posts"` i18n key to both `en.json` ("Related posts") and `es.json` ("Posts relacionados")
- Wires the component into `app/[lang]/blog/[name]/page.tsx` after the article content

## Test plan

- [ ] Open a blog post — "Related posts" section appears below the content with 2 cards
- [ ] Confirm it doesn't render on a blog with fewer than 2 other posts
- [ ] Check both `/en/blog/[slug]` and `/es/blog/[slug]` — heading translates correctly
- [ ] Clicking a related post card navigates to the correct post

Closes LES-67

https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8)_