### PR TITLE
feat(blog): add AuthorCard section at end of blog posts (LES-65)

### DIFF
--- a/app/[lang]/blog/[name]/page.tsx
+++ b/app/[lang]/blog/[name]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 
 import { Calendar } from 'lucide-react'
 
+import { AuthorCard } from '@/components/cards/author-card'
 import { SetBreadcrumb } from '@/components/set-breadcrumb'
 import { Badge } from '@/components/ui/badge'
 import { ScrollProgress } from '@/components/ui/scroll-progress'
@@ -154,6 +155,7 @@ export default async function BlogPostPage({ params }: PageParams) {
           className="blog-content animate-fade-in-up [animation-delay:200ms] [animation-fill-mode:both]"
           dangerouslySetInnerHTML={{ __html: post.content || '' }}
         />
+        <AuthorCard lang={lang} />
       </div>
     </>
   )

--- a/app/[lang]/dictionaries/en.json
+++ b/app/[lang]/dictionaries/en.json
@@ -47,5 +47,6 @@
   "blog": "Blog",
   "no-posts": "No posts yet",
   "made-with": "Made with",
-  "by": "by"
+  "by": "by",
+  "author-bio": "Software developer focused on building products with global impact. I write about code, endurance sports, and lessons from building in public."
 }

--- a/app/[lang]/dictionaries/es.json
+++ b/app/[lang]/dictionaries/es.json
@@ -47,5 +47,6 @@
   "blog": "Blog",
   "no-posts": "Aún no hay entradas",
   "made-with": "Hecho con",
-  "by": "por"
+  "by": "por",
+  "author-bio": "Desarrollador de software enfocado en construir productos con impacto global. Escribo sobre código, deportes de resistencia y lecciones de construir en público."
 }

--- a/components/cards/author-card.tsx
+++ b/components/cards/author-card.tsx
@@ -1,0 +1,61 @@
+import { getDictionary } from '@/app/[lang]/dictionaries'
+
+import Image from 'next/image'
+import NextLink from 'next/link'
+
+import { Github, Linkedin } from 'lucide-react'
+
+interface AuthorCardProps {
+  lang: 'en' | 'es'
+}
+
+export async function AuthorCard({ lang }: AuthorCardProps) {
+  const dictionary = await getDictionary(lang)
+
+  return (
+    <aside className="border-border bg-secondary/10 flex flex-col gap-4 rounded-xl border p-6 sm:flex-row sm:items-start sm:gap-6">
+      <div className="shrink-0">
+        <Image
+          src="/profile_pic.jpeg"
+          alt="Luis Esteban Ramirez"
+          width={80}
+          height={80}
+          className="rounded-full object-cover"
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <div>
+          <p className="font-heading text-foreground text-lg font-bold">
+            Luis Esteban Ramirez
+          </p>
+          <p className="text-muted-foreground text-sm">
+            {dictionary['software-developer']}
+          </p>
+        </div>
+        <p className="text-foreground/80 text-sm leading-relaxed">
+          {dictionary['author-bio']}
+        </p>
+        <div className="flex gap-4 pt-1">
+          <NextLink
+            href="https://github.com/LEstebanR"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-primary transition-colors"
+            aria-label="GitHub"
+          >
+            <Github className="h-5 w-5" />
+          </NextLink>
+          <NextLink
+            href="https://www.linkedin.com/in/lestebanr/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-primary transition-colors"
+            aria-label="LinkedIn"
+          >
+            <Linkedin className="h-5 w-5" />
+          </NextLink>
+        </div>
+      </div>
+    </aside>
+  )
+}


### PR DESCRIPTION
## Summary

- Creates `components/cards/author-card.tsx` as an async server component
- Displays: profile photo (`/profile_pic.jpeg`), name, `software-developer` title (translated), `author-bio` bio (translated), GitHub + LinkedIn icon links via `lucide-react`
- Added `"author-bio"` i18n key to `en.json` and `es.json`
- Integrated into `app/[lang]/blog/[name]/page.tsx` after the article content, before the closing `</div>`

## Test plan

- [ ] Open any blog post in `/en/blog/` — author card appears below the article with photo, bio and links
- [ ] Open the same post in `/es/blog/` — bio text is in Spanish
- [ ] Click GitHub and LinkedIn links — open in new tab correctly
- [ ] Verify the card looks correct in both light and dark mode

Closes LES-65

https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8)_