### PR TITLE
feat(ui): Add scroll-to-top button for long pages

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -14,6 +14,7 @@ import { BreadcrumbProvider } from '@/components/breadcrumb-provider'
 import { ThemeProvider } from '@/components/theme-provider'
 import { Footer } from '@/components/ui/footer'
 import { Header } from '@/components/ui/header'
+import { ScrollToTop } from '@/components/ui/scroll-to-top'
 import { getCanonicalUrl } from '@/lib/utils'
 
 const inter = Inter({
@@ -165,6 +166,7 @@ export default async function RootLayout({
               </main>
             </div>
             <Footer />
+            <ScrollToTop />
           </BreadcrumbProvider>
         </ThemeProvider>
         <SpeedInsights />

--- a/components/ui/scroll-to-top.tsx
+++ b/components/ui/scroll-to-top.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { ChevronUp } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+export function ScrollToTop() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 400)
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  if (!visible) return null
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      aria-label="Scroll to top"
+      className="animate-fade-in-scale fixed bottom-6 right-6 z-50 rounded-full shadow-md"
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+    >
+      <ChevronUp />
+    </Button>
+  )
+}


### PR DESCRIPTION
## Context

La homepage y los posts del blog no tenían forma de volver al top sin hacer scroll manual, lo cual es especialmente molesto en mobile. Este PR agrega un botón flotante que aparece al bajar 400px y permite volver al inicio con un scroll suave.

## Changes

- **`components/ui/scroll-to-top.tsx`** — nuevo componente cliente con listener de scroll, botón circular con `ChevronUp` y animación `animate-fade-in-scale` al aparecer
- **`app/[lang]/layout.tsx`** — agrega `<ScrollToTop />` dentro del `BreadcrumbProvider` para que esté disponible en todas las páginas

## Linear issues

- Closes LES-60

## Test plan

- [ ] Hacer scroll hacia abajo más de 400px en la homepage → el botón aparece en `bottom-6 right-6`
- [ ] Hacer click en el botón → la página sube suavemente al top
- [ ] Volver al top y verificar que el botón desaparece
- [ ] Verificar en mobile que el botón no obstruye el contenido
- [ ] Verificar en modo oscuro que el estilo es consistente
- [ ] `bun typecheck` passes (error preexistente en playwright.config.ts, no relacionado)
- [ ] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)