### PR TITLE
feat(ui): Add skeleton loaders for theme-dependent content in Hero and Contact

### DIFF
--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -8,6 +8,7 @@ import { useHasMounted } from '@/hooks/use-has-mounted'
 import { useLang } from '@/hooks/use-lang'
 
 import { ContactCard, ContactLink } from '@/components/cards/contact-card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { resolveContactLinks } from '@/lib/data'
 
 export function Contact() {
@@ -24,11 +25,18 @@ export function Contact() {
           {dictionary['contact']}
         </h1>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          {/* Placeholder para evitar layout shift */}
-          <div className="h-24" />
-          <div className="h-24" />
-          <div className="h-24" />
-          <div className="h-24" />
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="bg-card rounded-xl border py-6 px-6 flex items-center gap-4"
+            >
+              <Skeleton className="h-[35px] w-[35px] shrink-0 rounded-full" />
+              <div className="flex flex-col gap-1.5 flex-1">
+                <Skeleton className="h-4 w-28 rounded-md" />
+                <Skeleton className="h-3 w-36 rounded-md" />
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     )

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -9,6 +9,7 @@ import { useTheme } from 'next-themes'
 
 import { Badge } from '@/components/ui/badge'
 import { Link } from '@/components/ui/link'
+import { Skeleton } from '@/components/ui/skeleton'
 
 interface HeroProps {
   lang: 'en' | 'es'
@@ -71,7 +72,7 @@ export function Hero({ lang }: HeroProps) {
       </div>
       <div className="animate-fade-in-up mb-6 flex gap-4 [animation-delay:600ms] [animation-fill-mode:both] md:mb-0">
         <Link href="https://github.com/LEstebanR" withIcon>
-          {mounted && (
+          {mounted ? (
             <Image
               src={
                 resolvedTheme === 'dark'
@@ -83,6 +84,8 @@ export function Hero({ lang }: HeroProps) {
               width={30}
               height={30}
             />
+          ) : (
+            <Skeleton className="h-[30px] w-[30px] rounded-full" />
           )}
         </Link>
         <Link href="https://www.linkedin.com/in/lestebanr/" withIcon>
@@ -95,7 +98,7 @@ export function Hero({ lang }: HeroProps) {
           />
         </Link>
         <Link href="mailto:leramirezca@gmail.com">
-          {mounted && (
+          {mounted ? (
             <Image
               src={
                 resolvedTheme === 'dark'
@@ -107,6 +110,8 @@ export function Hero({ lang }: HeroProps) {
               width={33}
               height={33}
             />
+          ) : (
+            <Skeleton className="h-[33px] w-[33px] rounded-full" />
           )}
         </Link>
       </div>

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('animate-pulse rounded-md bg-muted', className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
## Context

`Hero` and `Contact` use `useHasMounted()` to avoid hydration mismatches with theme-dependent icons and links. Until the component mounts, they showed empty divs, causing a visible layout shift and blank space.

## Changes

- **`components/ui/skeleton.tsx`** — new `Skeleton` primitive (`animate-pulse bg-muted`) following shadcn/ui conventions
- **`components/hero.tsx`** — GitHub and mail icon placeholders replaced with `Skeleton` circles sized to match the real icons (30×30 and 33×33)
- **`components/contact.tsx`** — 4 empty `h-24` divs replaced with skeleton cards that mirror the `ContactCard` layout (icon circle + two text lines)

## Linear issues

- Closes LES-58

## Test plan

- [ ] On first load, Hero social icons show pulsing circle skeletons before hydration
- [ ] On first load, Contact section shows 4 skeleton cards matching the real card shape before hydration
- [ ] After mount, real icons and contact cards appear correctly in both light and dark mode
- [ ] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)