### PR TITLE
fix(seo): Consolidate keywords metadata to remove keyword stuffing

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -57,7 +57,7 @@ export async function generateMetadata({
       'Personal portfolio of Luis Esteban Ramirez, software developer specialized in web development and applications. Experience in React, TypeScript, and full-stack development.',
     keywords: [
       'Luis Esteban',
-      'Frontend Developer',
+      'Software Developer',
       'React',
       'Next.js',
       'TypeScript',
@@ -137,7 +137,7 @@ export default async function RootLayout({
         />
         <meta
           name="keywords"
-          content="Luis Esteban, Frontend Developer, React, Next.js, TypeScript, Tailwind CSS, Colombia, Portfolio"
+          content="Luis Esteban, Software Developer, React, Next.js, TypeScript, Tailwind CSS, Colombia, Portfolio"
         />
         <link
           rel="alternate"

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -56,17 +56,14 @@ export async function generateMetadata({
     description:
       'Personal portfolio of Luis Esteban Ramirez, software developer specialized in web development and applications. Experience in React, TypeScript, and full-stack development.',
     keywords: [
-      'software developer',
-      'web developer',
+      'Luis Esteban',
+      'Frontend Developer',
       'React',
+      'Next.js',
       'TypeScript',
-      'full-stack',
-      'frontend',
-      'portfolio',
-      'Luis Esteban Ramirez',
-      'desarrollador de software',
-      'desarrollador web',
-      'desarrollo full-stack',
+      'Tailwind CSS',
+      'Colombia',
+      'Portfolio',
     ],
     authors: [{ name: 'Luis Esteban Ramirez' }],
     creator: 'Luis Esteban Ramirez',
@@ -140,7 +137,7 @@ export default async function RootLayout({
         />
         <meta
           name="keywords"
-          content="Desarrollador web, Next.js, React, Portafolio, Esteban, Luis Esteban Ramirez, lesteban, developer, frontend, backend, fullstack, software, developer, developer web, developer frontend, developer backend, developer fullstack, developer software, developer web, developer frontend, developer backend, developer fullstack, developer software"
+          content="Luis Esteban, Frontend Developer, React, Next.js, TypeScript, Tailwind CSS, Colombia, Portfolio"
         />
         <link
           rel="alternate"


### PR DESCRIPTION
## Context

The `<meta name="keywords">` tag in `app/[lang]/layout.tsx` contained severe keyword stuffing — the word "developer" was repeated over a dozen times in various combinations. The `keywords` field in the Next.js metadata object also had redundant English/Spanish duplicates of the same concepts. Google can penalize pages for this practice.

## Changes

- **`app/[lang]/layout.tsx`** — Replaced the bloated 22-term keyword string in `<meta name="keywords">` with 8 clean, unique terms. Consolidated the metadata `keywords` array from 11 entries (with Spanish duplicates) to 8 unique, representative keywords matching the issue recommendation.

## Linear issues

- Closes LES-61

## Test plan

- [ ] Inspect page source — `<meta name="keywords">` shows exactly 8 unique terms with no repetition
- [ ] `bun typecheck` passes (pre-existing Playwright config error unrelated to this change)
- [ ] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)