### PR TITLE
feat(ui): Add count and rotating chevron to SeeMoreButton

### DIFF
--- a/components/experience.tsx
+++ b/components/experience.tsx
@@ -22,6 +22,7 @@ export function Experience() {
       <SeeMoreButton
         seeMoreCopy={dictionary['see-more']}
         seeLessCopy={dictionary['see-less']}
+        count={2}
       >
         <ExperienceCard job={EXPERIENCE.devpeoplz} />
         <ExperienceCard job={EXPERIENCE.nominapp} />

--- a/components/ui/see-more-button.tsx
+++ b/components/ui/see-more-button.tsx
@@ -2,22 +2,36 @@
 
 import { useState } from 'react'
 
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { ChevronDown } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 
 interface SeeMoreButtonProps {
   children: React.ReactNode
-  seeMoreCopy: React.ReactNode
-  seeLessCopy: React.ReactNode
+  seeMoreCopy: string
+  seeLessCopy: string
+  count?: number
+}
+
+function withCount(copy: string, count: number): string {
+  const idx = copy.lastIndexOf(' ')
+  if (idx === -1) return `${copy} ${count}`
+  return `${copy.slice(0, idx)} ${count}${copy.slice(idx)}`
 }
 
 export function SeeMoreButton({
   children,
   seeMoreCopy,
   seeLessCopy,
+  count,
 }: SeeMoreButtonProps) {
   const [seeMore, setSeeMore] = useState(false)
+
+  const label = seeMore
+    ? seeLessCopy
+    : count !== undefined
+      ? withCount(seeMoreCopy, count)
+      : seeMoreCopy
 
   return (
     <>
@@ -35,17 +49,10 @@ export function SeeMoreButton({
         onClick={() => setSeeMore(!seeMore)}
         className="border-primary text-primary hover:bg-primary mx-auto w-fit cursor-pointer rounded-full hover:text-white"
       >
-        {seeMore ? (
-          <>
-            {seeLessCopy}
-            <ChevronUp className="h-4 w-4" />
-          </>
-        ) : (
-          <>
-            {seeMoreCopy}
-            <ChevronDown className="h-4 w-4" />
-          </>
-        )}
+        {label}
+        <ChevronDown
+          className={`h-4 w-4 transition-transform duration-300 ${seeMore ? 'rotate-180' : ''}`}
+        />
       </Button>
     </>
   )


### PR DESCRIPTION
## Context

The `SeeMoreButton` lacked context about how many items are hidden and gave no visual feedback about the expanded/collapsed state. This makes the UX unclear — users can't tell how much is behind the button or whether they've already expanded it.

## Changes

- **`components/ui/see-more-button.tsx`** — Added optional `count` prop; when provided, the hidden item count is injected before the last word of `seeMoreCopy` (e.g. "See more" → "See 2 more"). Replaced separate `ChevronDown`/`ChevronUp` icons with a single `ChevronDown` that smoothly rotates `180°` on expand.
- **`components/experience.tsx`** — Passes `count={2}` to `SeeMoreButton` to surface the two hidden experience entries.

## Linear issues

- Closes LES-59

## Test plan

- [ ] Collapsed: button reads "Ver 2 más" (ES) / "See 2 more" (EN) with chevron pointing down
- [ ] Expanded: button reads "Ver menos" / "See less" with chevron pointing up (rotated)
- [ ] Chevron rotates smoothly with a CSS transition on click
- [ ] Content area animates open/close as before
- [ ] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)