### PR TITLE
feat(seo): Add Person JSON-LD schema to root layout

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -119,6 +119,19 @@ export async function generateMetadata({
   }
 }
 
+const personSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Luis Esteban Ramírez',
+  url: 'https://lesteban.dev',
+  sameAs: [
+    'https://github.com/LEstebanR',
+    'https://www.linkedin.com/in/lestebanr/',
+  ],
+  jobTitle: 'Software Developer',
+  knowsAbout: ['React', 'Next.js', 'TypeScript', 'Tailwind CSS'],
+}
+
 export default async function RootLayout({
   children,
   params,
@@ -144,6 +157,10 @@ export default async function RootLayout({
           type="application/rss+xml"
           title="Luis Esteban — Blog"
           href="/feed.xml"
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
         />
       </head>
       <body


### PR DESCRIPTION
## Context

The site already had JSON-LD `BlogPosting` schema on individual posts but lacked a `Person` schema at the root level. Adding it helps Google understand the site author's identity, links the profile to external social accounts, and improves structured-data rich results.

## Changes

- **`app/[lang]/layout.tsx`** — Added a `personSchema` constant with `@type: Person`, including `name`, `url`, `sameAs` (GitHub + LinkedIn), `jobTitle`, and `knowsAbout`. Injected as a `<script type="application/ld+json">` in the `<head>`. Used "Software Developer" (consistent with recent SEO keyword fix) rather than "Frontend Developer" from the issue draft.

## Linear issues

- Closes LES-62

## Test plan

- [ ] View page source — `<script type="application/ld+json">` is present in `<head>` with correct Person data
- [ ] Validate with Google Rich Results Test or schema.org validator
- [ ] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)