### PR TITLE
chore(config): Add .env.example and Dependabot weekly updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# ---------------------------------------------------------------------------
+# Site
+# ---------------------------------------------------------------------------
+
+# Public base URL used for canonical links and Open Graph tags.
+# Defaults to https://lesteban.dev when not set (see lib/utils.ts).
+NEXT_PUBLIC_SITE_URL=https://lesteban.dev
+
+# ---------------------------------------------------------------------------
+# CI / Testing
+# ---------------------------------------------------------------------------
+
+# Set automatically by CI providers (GitHub Actions, Vercel, etc.).
+# Playwright uses this to toggle retries, parallelism, and server reuse.
+CI=true
+
+# ---------------------------------------------------------------------------
+# Analytics (Vercel)
+# ---------------------------------------------------------------------------
+
+# Injected automatically by Vercel for @vercel/analytics and
+# @vercel/speed-insights — no manual configuration required.
+# NEXT_PUBLIC_VERCEL_ENV=production
+# NEXT_PUBLIC_VERCEL_URL=lesteban.dev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      production-dependencies:
+        dependency-type: production


### PR DESCRIPTION
## Context

New contributors cloning the repo had no way to know which environment variables to configure. Additionally, with no automation in place, npm dependencies were accumulating drift silently. Both issues are addressed with minimal config files.

## Changes

- **`.env.example`** — Documents `NEXT_PUBLIC_SITE_URL` (canonical URL base), `CI` (used by Playwright for retries/parallelism), and Vercel analytics vars (auto-injected, listed as reference). Placeholder values with explanatory comments.
- **`.github/dependabot.yml`** — Weekly npm update checks grouped into one PR for dev deps and one for production deps, avoiding feed saturation.

## Linear issues

- Closes LES-69
- Closes LES-70

## Test plan

- [ ] `.env.example` is present at repo root with no real secrets
- [ ] `.github/dependabot.yml` is valid YAML and appears in GitHub's Dependabot settings
- [ ] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)