### PR TITLE
refac(config): Extract BASE_URL, SITE_NAME, TWITTER_HANDLE to lib/constants

### DIFF
--- a/app/[lang]/blog/[name]/page.tsx
+++ b/app/[lang]/blog/[name]/page.tsx
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge'
 import { ScrollProgress } from '@/components/ui/scroll-progress'
 
 import { getAllPostUrls, getPostByUrl } from '@/lib/blog'
+import { BASE_URL } from '@/lib/constants'
 import { getCanonicalUrl } from '@/lib/utils'
 
 type PageParams = {
@@ -116,7 +117,7 @@ export default async function BlogPostPage({ params }: PageParams) {
     },
     keywords: post.tags?.join(', '),
     inLanguage: lang,
-    url: `https://lesteban.dev/${lang}/blog/${post.url}`,
+    url: `${BASE_URL}/${lang}/blog/${post.url}`,
   }
 
   return (

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -15,6 +15,7 @@ import { ThemeProvider } from '@/components/theme-provider'
 import { Footer } from '@/components/ui/footer'
 import { Header } from '@/components/ui/header'
 import { ScrollToTop } from '@/components/ui/scroll-to-top'
+import { BASE_URL, SITE_NAME, TWITTER_HANDLE } from '@/lib/constants'
 import { getCanonicalUrl } from '@/lib/utils'
 
 const inter = Inter({
@@ -84,7 +85,7 @@ export async function generateMetadata({
       title: 'Luis Esteban Ramirez | Software Developer',
       description:
         'Personal portfolio of Luis Esteban Ramirez, software developer specialized in web development and applications. Experience in React, TypeScript, and full-stack development.',
-      siteName: 'LEsteban Portfolio',
+      siteName: `${SITE_NAME} Portfolio`,
       images: [
         {
           url: '/og-image.jpg',
@@ -99,7 +100,7 @@ export async function generateMetadata({
       title: 'Luis Esteban Ramirez | Software Developer',
       description:
         'Personal portfolio of Luis Esteban Ramirez, software developer specialized in web development and applications. Experience in React, TypeScript, and full-stack development.',
-      creator: '@lestebanr',
+      creator: TWITTER_HANDLE,
       images: ['/og-image.jpg'],
     },
     robots: {
@@ -123,7 +124,7 @@ const personSchema = {
   '@context': 'https://schema.org',
   '@type': 'Person',
   name: 'Luis Esteban Ramírez',
-  url: 'https://lesteban.dev',
+  url: BASE_URL,
   sameAs: [
     'https://github.com/LEstebanR',
     'https://www.linkedin.com/in/lestebanr/',

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,6 +1,5 @@
 import { getAllPosts } from '@/lib/blog'
-
-const BASE_URL = 'https://lesteban.dev'
+import { BASE_URL } from '@/lib/constants'
 
 function escapeXml(text: string): string {
   return text

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,9 +1,10 @@
 import { MetadataRoute } from 'next'
 
 import { getAllPostUrls } from '@/lib/blog'
+import { BASE_URL } from '@/lib/constants'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = 'https://lesteban.dev'
+  const baseUrl = BASE_URL
 
   // Get all blog post URLs for both languages
   const enPostUrls = await getAllPostUrls('en')

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,3 @@
+export const BASE_URL = 'https://lesteban.dev'
+export const SITE_NAME = 'LEsteban'
+export const TWITTER_HANDLE = '@lestebanr'

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,11 +1,12 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
+import { BASE_URL } from '@/lib/constants'
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-const BASE_URL = 'https://lesteban.dev'
 
 export function getCanonicalUrl(path: string): string {
   // Remove leading slash if present to avoid double slashes


### PR DESCRIPTION
## Context

The domain `https://lesteban.dev`, site name `LEsteban`, and Twitter handle `@lestebanr` were duplicated across five files. A domain change would require hunting down every occurrence — `lib/constants.ts` makes it a one-line update.

## Changes

- **`lib/constants.ts`** *(new)* — Single source of truth for `BASE_URL`, `SITE_NAME`, and `TWITTER_HANDLE`.
- **`lib/utils.ts`** — Imports `BASE_URL` from constants instead of declaring it locally.
- **`app/sitemap.ts`** — Replaces inline `'https://lesteban.dev'` with `BASE_URL`.
- **`app/feed.xml/route.ts`** — Replaces local `BASE_URL` constant with import.
- **`app/[lang]/blog/[name]/page.tsx`** — Replaces hardcoded domain in JSON-LD `url` with `BASE_URL`.
- **`app/[lang]/layout.tsx`** — Replaces hardcoded domain in `personSchema.url`, `siteName` with `SITE_NAME`, and Twitter `creator` with `TWITTER_HANDLE`.

## Linear issues

- Closes LES-71

## Test plan

- [ ] `bun test lib/ middleware.test.ts tests/` passes (canonical URL tests still assert the correct string)
- [ ] `bun lint` passes
- [ ] Build produces no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)