### PR TITLE
feat(seo): add OG, Twitter and description metadata to blog list page (LES-131)

### DIFF
--- a/app/[lang]/blog/page.tsx
+++ b/app/[lang]/blog/page.tsx
@@ -23,8 +23,12 @@ export async function generateMetadata({
   const alternateLang = lang === 'en' ? 'es' : 'en'
   const alternateUrl = getCanonicalUrl(`/${alternateLang}/blog`)
 
+  const title = `${dictionary['blog']} | Luis Esteban`
+  const description = dictionary['blog-description']
+
   return {
-    title: dictionary['blog'],
+    title,
+    description,
     alternates: {
       canonical: canonicalUrl,
       languages: {
@@ -32,6 +36,22 @@ export async function generateMetadata({
         [alternateLang]: alternateUrl,
         'x-default': canonicalUrl,
       },
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonicalUrl,
+      type: 'website',
+      locale: lang === 'en' ? 'en_US' : 'es_ES',
+      alternateLocale: lang === 'en' ? 'es_ES' : 'en_US',
+      images: [{ url: '/og-image.jpg', width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      creator: '@lestebanr',
+      images: ['/og-image.jpg'],
     },
   }
 }

--- a/app/[lang]/dictionaries/en.json
+++ b/app/[lang]/dictionaries/en.json
@@ -46,6 +46,7 @@
   "indie-hacker-in-progress": "Indie Hacker in progress",
   "blog": "Blog",
   "no-posts": "No posts yet",
+  "blog-description": "Articles on software development, productivity, and personal growth by Luis Esteban Ramirez.",
   "made-with": "Made with",
   "by": "by",
   "related-posts": "Related posts"

--- a/app/[lang]/dictionaries/es.json
+++ b/app/[lang]/dictionaries/es.json
@@ -46,6 +46,7 @@
   "indie-hacker-in-progress": "Indie Hacker en proceso",
   "blog": "Blog",
   "no-posts": "Aún no hay entradas",
+  "blog-description": "Artículos sobre desarrollo de software, productividad y crecimiento personal por Luis Esteban Ramírez.",
   "made-with": "Hecho con",
   "by": "por",
   "related-posts": "Posts relacionados"


### PR DESCRIPTION
## Summary

- Adds `description`, `openGraph`, and `twitter` fields to `generateMetadata` in `app/[lang]/blog/page.tsx`
- Description strings externalized to dictionaries as `"blog-description"` key (en + es) so both languages stay in sync
- Title formatted as `"Blog | Luis Esteban"` for both OG and Twitter
- `openGraph.alternateLocale` set correctly per language
- Twitter card type `summary_large_image` with `/og-image.jpg`

## Test plan

- [ ] Share `/en/blog` on Twitter/Slack — rich card appears with title, description and image
- [ ] Share `/es/blog` — description is in Spanish
- [ ] Check Google Search Console preview — meta description shows correctly

Closes LES-131

https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8)_