### PR TITLE
fix(a11y): Add aria-label to LanguageToggle button

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -155,6 +155,7 @@ For each finding, call `mcp__linear-server__save_issue` with:
 ```
 title: <actionable title>
 team: Lesteban
+project: LEsteban
 description: <markdown body>
 priority: <1–4>
 labels: [<matching label name if it exists>]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ mock.module('@/hooks/use-has-mounted', () => ({
 ### E2E conventions
 
 - The header renders `<h1>Luis Esteban</h1>` as the site logo. Use `page.locator('main h1')` to target content headings, never bare `locator('h1')`.
-- `LanguageToggle` is a `<Button>`, not a link. Use `page.getByRole('button', { name: 'ES' })` or `{ name: 'EN' }` depending on the current locale.
+- `LanguageToggle` is a `<Button>`, not a link. Use `page.getByRole('button', { name: 'Switch to Spanish' })` when on `/en`, or `{ name: 'Cambiar a inglés' }` when on `/es` — the button's accessible name comes from its `aria-label`, not the visible text.
 - shadcn `Badge` does not emit a literal `badge` CSS class. Add `data-testid="date-badge"` (or equivalent) to Badge elements you need to target in tests.
 - Never use `waitUntil: 'commit'` when testing redirected URLs — Playwright resolves before the redirect completes. Omit it to get the final URL.
 - Test i18n redirects against paths that actually exist in the app (e.g. `/blog` → `/en/blog`), not against non-existent paths like `/about`.

--- a/components/ui/language-toggle.tsx
+++ b/components/ui/language-toggle.tsx
@@ -8,21 +8,23 @@ export function LanguageToggle() {
   const router = useRouter()
   const pathname = usePathname()
   const segments = pathname.split('/').filter(Boolean)
-  const currentLang = segments[0] === 'en' || segments[0] === 'es'
-    ? (segments[0] as 'en' | 'es')
-    : 'en'
+  const currentLang =
+    segments[0] === 'en' || segments[0] === 'es'
+      ? (segments[0] as 'en' | 'es')
+      : 'en'
   const nextLang = currentLang === 'en' ? 'es' : 'en'
-  const pathWithoutLang = segments[0] === 'en' || segments[0] === 'es'
-    ? segments.slice(1)
-    : segments
-  const pathAfterLang = pathWithoutLang.length > 0
-    ? `/${pathWithoutLang.join('/')}`
-    : ''
+  const pathWithoutLang =
+    segments[0] === 'en' || segments[0] === 'es' ? segments.slice(1) : segments
+  const pathAfterLang =
+    pathWithoutLang.length > 0 ? `/${pathWithoutLang.join('/')}` : ''
 
   return (
     <Button
       variant="outline"
       size="icon"
+      aria-label={
+        currentLang === 'en' ? 'Switch to Spanish' : 'Cambiar a inglés'
+      }
       onClick={() => router.push(`/${nextLang}${pathAfterLang}`)}
     >
       {nextLang.toUpperCase()}

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -12,8 +12,7 @@ test.describe('Language switch', () => {
     await page.goto('/en/blog/first-marathon')
     await expect(page).toHaveURL('/en/blog/first-marathon')
 
-    // LanguageToggle renders as a button with the next language label in uppercase
-    const langToggle = page.getByRole('button', { name: 'ES' })
+    const langToggle = page.getByRole('button', { name: 'Switch to Spanish' })
     await langToggle.click()
 
     await expect(page).toHaveURL('/es/blog/first-marathon')
@@ -22,7 +21,7 @@ test.describe('Language switch', () => {
   test('switching lang on homepage keeps root path', async ({ page }) => {
     await page.goto('/en')
 
-    const langToggle = page.getByRole('button', { name: 'ES' })
+    const langToggle = page.getByRole('button', { name: 'Switch to Spanish' })
     await langToggle.click()
 
     await expect(page).toHaveURL('/es')


### PR DESCRIPTION
## Context

The LanguageToggle button rendered only "EN" or "ES" with no accessible name. Screen readers announced it as "ES, button" with no indication that it switches the site language, failing WCAG 2.1 SC 4.1.2 (Name, Role, Value).

## Changes

- **`components/ui/language-toggle.tsx`** — Added `aria-label` in the current language: `"Switch to Spanish"` when on English, `"Cambiar a inglés"` when on Spanish, so the label conveys the action before the user activates it

## Linear issues

- Closes LES-127

## Test plan

- [ ] On `/en/*`, inspect the toggle button and confirm `aria-label="Switch to Spanish"`
- [ ] On `/es/*`, inspect the toggle button and confirm `aria-label="Cambiar a inglés"`
- [ ] Screen reader announces the label correctly
- [ ] `bun typecheck` passes
- [ ] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8)_