### PR TITLE
fix(a11y): Guard animations with prefers-reduced-motion

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -316,3 +316,13 @@ html {
 .animate-float {
   animation: float 3s ease-in-out infinite;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -1,17 +1,17 @@
 'use client'
 
 import { getClientDictionary } from '@/app/[lang]/dictionaries/client'
-import { motion } from 'framer-motion'
+import { useLang } from '@/hooks/use-lang'
+import { motion, useReducedMotion } from 'framer-motion'
 
 import Link from 'next/link'
 
 import { Heart } from 'lucide-react'
 
-import { useLang } from '@/hooks/use-lang'
-
 export function Footer() {
   const lang = useLang()
   const dictionary = getClientDictionary(lang)
+  const prefersReduced = useReducedMotion()
 
   return (
     <footer className="my-4 w-full">
@@ -32,16 +32,14 @@ export function Footer() {
             {dictionary['made-with' as keyof typeof dictionary]}
           </motion.span>
           <motion.div
-            animate={{
-              scale: [1, 1.5, 1],
-            }}
-            transition={{
-              duration: 1.5,
-              repeat: Infinity,
-              repeatType: 'reverse',
-            }}
+            animate={prefersReduced ? {} : { scale: [1, 1.5, 1] }}
+            transition={
+              prefersReduced
+                ? {}
+                : { duration: 1.5, repeat: Infinity, repeatType: 'reverse' }
+            }
           >
-            <Heart className="h-4 w-4 fill-secondary text-secondary" />
+            <Heart className="fill-secondary text-secondary h-4 w-4" />
           </motion.div>
           <motion.span
             initial={{ opacity: 0 }}


### PR DESCRIPTION
## Context

Users with vestibular disorders, epilepsy, or motion sensitivity are harmed by persistent looping animations. The infinite heart beat in the footer was a WCAG 2.2.2 (Pause, Stop, Hide) violation, and the site had no global guard for CSS animations under `prefers-reduced-motion`.

## Changes

- **`app/globals.css`** — Added `@media (prefers-reduced-motion: reduce)` rule that collapses all CSS animation durations to `0.01ms` and limits iteration count to `1`, disabling `animate-float`, `animate-fade-in-up`, and `animate-fade-in-scale` for affected users
- **`components/ui/footer.tsx`** — Imported `useReducedMotion` from framer-motion and used it to conditionally disable the infinite heart scale animation (`scale: [1, 1.5, 1]`, `repeat: Infinity`) when the user prefers reduced motion

## Linear issues

- Closes LES-129

## Test plan

- [ ] Enable "Reduce motion" in OS accessibility settings and verify the heart in the footer is static
- [ ] Verify hero profile image no longer floats when reduced motion is on
- [ ] Verify fade-in animations are instant (no visible motion) when reduced motion is on
- [ ] Disable reduced motion — confirm all animations play normally
- [ ] `bun typecheck` passes
- [ ] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8)_