### PR TITLE
feat(a11y): Add skip-to-main-content link to layout

### DIFF
--- a/app/[lang]/dictionaries/en.json
+++ b/app/[lang]/dictionaries/en.json
@@ -49,5 +49,6 @@
   "blog-description": "Articles on software development, productivity, and personal growth by Luis Esteban Ramirez.",
   "made-with": "Made with",
   "by": "by",
-  "related-posts": "Related posts"
+  "related-posts": "Related posts",
+  "skip-to-content": "Skip to main content"
 }

--- a/app/[lang]/dictionaries/es.json
+++ b/app/[lang]/dictionaries/es.json
@@ -49,5 +49,6 @@
   "blog-description": "Artículos sobre desarrollo de software, productividad y crecimiento personal por Luis Esteban Ramírez.",
   "made-with": "Hecho con",
   "by": "por",
-  "related-posts": "Posts relacionados"
+  "related-posts": "Posts relacionados",
+  "skip-to-content": "Saltar al contenido principal"
 }

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -1,20 +1,18 @@
+import { getDictionary } from '@/app/[lang]/dictionaries'
 import '@/app/globals.css'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 
 import type { Metadata } from 'next'
 
-import {
-  Bricolage_Grotesque,
-  Inter,
-  JetBrains_Mono,
-} from 'next/font/google'
+import { Bricolage_Grotesque, Inter, JetBrains_Mono } from 'next/font/google'
 
 import { BreadcrumbProvider } from '@/components/breadcrumb-provider'
 import { ThemeProvider } from '@/components/theme-provider'
 import { Footer } from '@/components/ui/footer'
 import { Header } from '@/components/ui/header'
 import { ScrollToTop } from '@/components/ui/scroll-to-top'
+
 import { BASE_URL, SITE_NAME, TWITTER_HANDLE } from '@/lib/constants'
 import { getCanonicalUrl } from '@/lib/utils'
 
@@ -142,6 +140,7 @@ export default async function RootLayout({
 }) {
   const { lang } = await params
   const validLang = lang === 'es' ? 'es' : 'en'
+  const dictionary = await getDictionary(validLang)
   return (
     <html lang={validLang} suppressHydrationWarning>
       <head>
@@ -173,9 +172,18 @@ export default async function RootLayout({
           disableTransitionOnChange
         >
           <BreadcrumbProvider>
+            <a
+              href="#main-content"
+              className="focus:bg-background focus:text-foreground focus:ring-ring sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:px-4 focus:py-2 focus:ring-2"
+            >
+              {dictionary['skip-to-content']}
+            </a>
             <div className="flex w-full flex-1 flex-col items-center justify-center">
               <Header />
-              <main className="mt-16 flex w-full flex-1 flex-col px-2 md:px-4 lg:w-3/6 lg:px-0 2xl:w-2/6">
+              <main
+                id="main-content"
+                className="mt-16 flex w-full flex-1 flex-col px-2 md:px-4 lg:w-3/6 lg:px-0 2xl:w-2/6"
+              >
                 {children}
                 <Analytics />
               </main>


### PR DESCRIPTION
## Context

Keyboard-only and screen reader users had to tab through the entire fixed header (logo, blog link, language toggle, theme toggle) on every page before reaching main content. There was no bypass mechanism, violating WCAG 2.1 SC 2.4.1 (Bypass Blocks, Level AA).

## Changes

- **`app/[lang]/layout.tsx`** — Added a visually-hidden skip link as the first focusable element in `<body>` (before `<Header>`); it becomes visible on focus via `focus:not-sr-only`. Added `id="main-content"` to the `<main>` element as the skip target. Also loads `getDictionary` to render the label in the current locale
- **`app/[lang]/dictionaries/en.json`** — Added `"skip-to-content": "Skip to main content"`
- **`app/[lang]/dictionaries/es.json`** — Added `"skip-to-content": "Saltar al contenido principal"`

## Linear issues

- Closes LES-128

## Test plan

- [ ] Tab to the page — first focus reveals the skip link above the header
- [ ] Activating the link jumps focus to `<main id="main-content">`
- [ ] On `/es/*`, the skip link reads "Saltar al contenido principal"
- [ ] On `/en/*`, the skip link reads "Skip to main content"
- [ ] Skip link is invisible when not focused (visually hidden)
- [ ] `bun typecheck` passes
- [ ] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8)_