### PR TITLE
feat(config): Add HTTP security headers to next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,15 @@
 import type { NextConfig } from 'next'
 
+const csp = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "img-src 'self' data: https:",
+  "font-src 'self' https://fonts.gstatic.com",
+  "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com",
+  "frame-ancestors 'none'",
+].join('; ')
+
 const nextConfig: NextConfig = {
   images: {
     formats: ['image/avif', 'image/webp'],
@@ -8,6 +18,27 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     optimizePackageImports: ['lucide-react', 'framer-motion'],
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          { key: 'Content-Security-Policy', value: csp },
+        ],
+      },
+    ]
   },
 }
 


### PR DESCRIPTION
## Context

`next.config.ts` had no HTTP security headers, leaving the site open to clickjacking, MIME-type sniffing, and information leakage. Security scanners would rate it F, which reflects poorly on a developer portfolio.

## Changes

- **`next.config.ts`** — Added a `headers()` function applying these headers to all routes (`/(.*)`):
  - `X-Frame-Options: DENY` — prevents clickjacking
  - `X-Content-Type-Options: nosniff` — prevents MIME sniffing
  - `Referrer-Policy: strict-origin-when-cross-origin` — limits referrer leakage
  - `Permissions-Policy: camera=(), microphone=(), geolocation=()` — disables unused browser APIs
  - `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` — enforces HTTPS
  - `Content-Security-Policy` — tailored to actual third-party sources: Google Fonts (`fonts.googleapis.com`, `fonts.gstatic.com`), Vercel Analytics (`va.vercel-scripts.com`), Vercel Speed Insights (`vitals.vercel-insights.com`)

## Linear issues

- Closes LES-132

## Test plan

- [ ] Run the site and verify pages load normally with no CSP violations in the browser console
- [ ] Check response headers in DevTools Network tab — all 6 headers present
- [ ] Verify Google Fonts load correctly (font-src allows `fonts.gstatic.com`)
- [ ] Verify Vercel Analytics and Speed Insights report correctly (connect-src allows their endpoints)
- [ ] `bun typecheck` passes
- [ ] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8)_