### PR TITLE
feat(blog): Render tags on blog post pages and card list

### DIFF
--- a/app/[lang]/blog/[name]/page.tsx
+++ b/app/[lang]/blog/[name]/page.tsx
@@ -155,6 +155,17 @@ export default async function BlogPostPage({ params }: PageParams) {
                 {post.date}
               </span>
             </Badge>
+            {post.tags &&
+              post.tags.length > 0 &&
+              post.tags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant="secondary"
+                  className="rounded-full text-xs"
+                >
+                  {tag}
+                </Badge>
+              ))}
           </div>
 
           <div className="border-border via-border h-px w-full bg-gradient-to-r from-transparent to-transparent" />

--- a/components/cards/blog-card.tsx
+++ b/components/cards/blog-card.tsx
@@ -1,10 +1,11 @@
 'use client'
 
+import { useLang } from '@/hooks/use-lang'
+
 import Image from 'next/image'
 import NextLink from 'next/link'
 
-import { useLang } from '@/hooks/use-lang'
-
+import { Badge } from '@/components/ui/badge'
 import { Card, CardHeader, CardTitle } from '@/components/ui/card'
 
 type BlogPost = {
@@ -14,6 +15,7 @@ type BlogPost = {
   date: string
   description: string
   image: string
+  tags?: string[]
 }
 
 export function BlogCard({ post }: { post: BlogPost }) {
@@ -21,7 +23,7 @@ export function BlogCard({ post }: { post: BlogPost }) {
 
   return (
     <NextLink href={`/${lang}/blog/${post.url}`}>
-      <Card className="border-secondary group flex h-full w-full cursor-pointer flex-col gap-0 overflow-hidden border-2 p-0 transition-all duration-300 hover:border-primary/50">
+      <Card className="border-secondary group hover:border-primary/50 flex h-full w-full cursor-pointer flex-col gap-0 overflow-hidden border-2 p-0 transition-all duration-300">
         <div className="relative block h-64 w-full overflow-hidden lg:h-56">
           <Image
             src={post.image}
@@ -35,6 +37,19 @@ export function BlogCard({ post }: { post: BlogPost }) {
           <CardTitle className="group-hover:text-primary flex w-full items-start justify-between gap-2 px-6 py-4 transition-colors">
             <span className="font-heading text-lg font-bold">{post.title}</span>
           </CardTitle>
+          {post.tags && post.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 px-6 pb-4">
+              {post.tags.slice(0, 3).map((tag) => (
+                <Badge
+                  key={tag}
+                  variant="secondary"
+                  className="rounded-full text-xs"
+                >
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
         </CardHeader>
       </Card>
     </NextLink>

--- a/tests/cards.test.tsx
+++ b/tests/cards.test.tsx
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
-import React from 'react'
 import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+import React from 'react'
 
 mock.module('next/navigation', () => ({
   usePathname: () => '/en',
@@ -100,6 +101,12 @@ describe('BlogCard', () => {
     render(<BlogCard post={post} />)
     const img = screen.getByAltText('My First Post')
     expect(img).toBeDefined()
+  })
+
+  test('renders tag badges when tags are present', () => {
+    render(<BlogCard post={{ ...post, tags: ['react', 'nextjs'] }} />)
+    expect(screen.getByText('react')).toBeDefined()
+    expect(screen.getByText('nextjs')).toBeDefined()
   })
 })
 


### PR DESCRIPTION
## Context

`post.tags` was available in the `BlogPost` type and used in SEO `keywords` metadata, but never rendered in the UI. Readers had no way to see a post's topics at a glance, making the blog list look homogeneous and harder to scan.

## Changes

- **`app/[lang]/blog/[name]/page.tsx`** — Tags rendered as `Badge` chips (variant `secondary`, `rounded-full`) inline with the date in the post header; renders all tags when present
- **`components/cards/blog-card.tsx`** — Added `tags?: string[]` to the local `BlogPost` type; renders up to 3 tag chips in the card footer below the title, hidden when no tags exist

## Linear issues

- Closes LES-139

## Test plan

- [ ] Open a blog post with tags — confirm chips appear next to the date in the header
- [ ] Open the blog list — confirm up to 3 tag chips appear below each card title
- [ ] Posts without tags render no chip area (no empty gap)
- [ ] Both light and dark mode look correct
- [ ] `bun typecheck` passes
- [ ] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBNpFgRx3qz5fvjkDPvJa8)_